### PR TITLE
Move env vars to config repo

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-FEE_GROUP_REFERENCE_SERVICE_URL=https://etapi.employmenttribunals.service.gov.uk/1/fgr-office
-
-# FIXME replace with URL user is redirected to. Don't know what it is right now.
-PAYMENT_GATEWAY_PING_ENDPOINT=https://mdepayments.epdq.co.uk/ncol/test/backoffice?BRANDING=EPDQ&lang=1
-
-EPDQ_PSPID=ministry2
-EPDQ_SECRET_IN="m/mcr\\q]QKE'Pmal;ke2"
-EPDQ_SECRET_OUT="sEtw3k4m.a xl23lmw;la"

--- a/package.sh
+++ b/package.sh
@@ -117,7 +117,7 @@ bundle --quiet \
 rm -rf bin
 # Add the envvars defined in .env to avoid errors during the assets:precompile stage
 set -a
-. .env
+. /etc/docker_env.d/et
 set +a
 npm install
 bundle exec rake rails:update:bin


### PR DESCRIPTION
* Remove env vars from repo

Note: whenever we add a new env var with ENV.fetch we will need to put the env var in our config repo so that the assets precompile still works.