### PR TITLE
Allows contextual lookup when using i18n with error messages for postcode validations

### DIFF
--- a/app/validators/post_code_validator.rb
+++ b/app/validators/post_code_validator.rb
@@ -2,9 +2,8 @@ class PostCodeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if value.present?
       postcode = UKPostcode.new(value)
-      message  = options[:message] || I18n.t('errors.messages.invalid')
 
-      record.errors[attribute] << message unless postcode.valid? && postcode.full?
+      record.errors.add(attribute, :invalid) unless postcode.valid? && postcode.full?
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -688,6 +688,7 @@ en:
               blank: You must provide information for this field
             address_post_code:
               blank: You must provide information for this field
+              invalid: You must provide a valid post code
         employment:
           attributes:
             start_date:

--- a/spec/forms/additional_claimants_form/additional_claimant_spec.rb
+++ b/spec/forms/additional_claimants_form/additional_claimant_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe AdditionalClaimantsForm::AdditionalClaimant, :type => :form do
     it { is_expected.to ensure_length_of(:address_post_code).is_at_most(8) }
   end
 
-  include_examples "Postcode validation", attribute_prefix: 'address'
+  include_examples "Postcode validation",
+    attribute_prefix: 'address',
+    error_message: 'is invalid'
 
   let(:attributes) do
     {

--- a/spec/forms/additional_respondents_form/additional_respondent_spec.rb
+++ b/spec/forms/additional_respondents_form/additional_respondent_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe AdditionalRespondentsForm::AdditionalRespondent, :type => :form d
     end
   end
 
-  include_examples "Postcode validation", attribute_prefix: 'address'
+  include_examples "Postcode validation",
+    attribute_prefix: 'address',
+    error_message: 'is invalid'
 
   let(:attributes) do
     {

--- a/spec/forms/claimant_form_spec.rb
+++ b/spec/forms/claimant_form_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe ClaimantForm, :type => :form do
         before { subject.address_country = 'united_kingdom' }
 
         it { is_expected.to ensure_length_of(:address_post_code).is_at_most(8) }
-        include_examples "Postcode validation", attribute_prefix: 'address'
+
+        include_examples "Postcode validation",
+          attribute_prefix: 'address',
+          error_message: 'You must provide a valid post code'
       end
 
       context 'when address_country is not united_kingdom' do

--- a/spec/forms/representative_form_spec.rb
+++ b/spec/forms/representative_form_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe RepresentativeForm, :type => :form do
       it { is_expected.to ensure_length_of(:mobile_number).is_at_most(21) }
       it { is_expected.to ensure_length_of(:dx_number).is_at_most(20) }
 
-      include_examples "Postcode validation", attribute_prefix: 'address'
+      include_examples "Postcode validation",
+        attribute_prefix: 'address',
+        error_message: 'is invalid'
     end
 
     context 'when has_representative? == false' do

--- a/spec/forms/respondent_form_spec.rb
+++ b/spec/forms/respondent_form_spec.rb
@@ -136,6 +136,11 @@ RSpec.describe RespondentForm, :type => :form do
     end
   end
 
-  include_examples "Postcode validation", attribute_prefix: 'address'
-  include_examples "Postcode validation", attribute_prefix: 'work_address'
+  include_examples "Postcode validation",
+    attribute_prefix: 'address',
+    error_message: 'is invalid'
+
+  include_examples "Postcode validation",
+    attribute_prefix: 'work_address',
+    error_message: 'is invalid'
 end

--- a/spec/support/shared_examples/postcode_validation.rb
+++ b/spec/support/shared_examples/postcode_validation.rb
@@ -1,7 +1,8 @@
 RSpec.shared_examples 'Postcode validation' do |options|
   describe 'validating a postcode' do
-    let(:prefix) { options[:attribute_prefix] }
-    let(:errors) { subject.errors[:"#{prefix}_post_code"] }
+    let(:prefix)        { options[:attribute_prefix] }
+    let(:errors)        { subject.errors[:"#{prefix}_post_code"] }
+    let(:error_message) { options[:error_message] }
 
     context 'when no postcode' do
       before do
@@ -10,7 +11,7 @@ RSpec.shared_examples 'Postcode validation' do |options|
       end
 
       it 'does not add any errors' do
-        expect(errors).not_to include 'is invalid'
+        expect(errors).not_to include error_message
       end
     end
 
@@ -21,7 +22,7 @@ RSpec.shared_examples 'Postcode validation' do |options|
       end
 
       it 'adds an error to the postcode attribute' do
-        expect(errors).to include "is invalid"
+        expect(errors).to include error_message
       end
     end
 
@@ -32,7 +33,7 @@ RSpec.shared_examples 'Postcode validation' do |options|
       end
 
       it 'adds an error to the postcode attribute' do
-        expect(errors).to include "is invalid"
+        expect(errors).to include error_message
       end
     end
 


### PR DESCRIPTION
:bikini: :sunrise: :beers: 