### PR TITLE
Mailer Previews Fix: Confirmation Email Arity Change

### DIFF
--- a/spec/mailer_previews/confirmation_email_preview.rb
+++ b/spec/mailer_previews/confirmation_email_preview.rb
@@ -19,8 +19,8 @@ class ConfirmationEmailPreview < ActionMailer::Preview
     claim_for :group_payment_with_remission_payment_failed
   end
 
-  private def claim_for(trait, email='user@example.com')
-    claim = FactoryGirl.create(:claim, trait)
-    BaseMailer.confirmation_email(claim, email)
+  private def claim_for(trait)
+    claim = FactoryGirl.create(:claim, :with_pdf, trait)
+    BaseMailer.confirmation_email(claim)
   end
 end


### PR DESCRIPTION
Arity change fixes mailer previews. 

We also pass multiple traits to FG in order to ensure PDF is available. PDF generation was removed from the mailers.