### PR TITLE
Confirmation page permutations

### DIFF
--- a/app/presenters/confirmation_email_presenter.rb
+++ b/app/presenters/confirmation_email_presenter.rb
@@ -7,17 +7,7 @@ class ConfirmationEmailPresenter < ConfirmationPresenter
     "#{primary_claimant.first_name} #{primary_claimant.last_name}"
   end
 
-  def payment_failed?
-    fee_to_pay? && payment.blank?
-  end
-
   private
-
-  def items
-    %i<submission_information attachments payment_amount>.tap do |arr|
-      arr.delete :payment_amount unless fee_to_pay?
-    end
-  end
 
   def payment_type
     payment_failed? ? :payment_not_processed : :normal

--- a/app/presenters/confirmation_presenter.rb
+++ b/app/presenters/confirmation_presenter.rb
@@ -9,6 +9,10 @@ class ConfirmationPresenter < Presenter
     end
   end
 
+  def payment_failed?
+    fee_to_pay? && payment.blank?
+  end
+
   def attachments
     attachment_filenames.map { |f| sanitize(f) }.join(tag :br).html_safe
   end
@@ -24,10 +28,14 @@ class ConfirmationPresenter < Presenter
   private
 
   def items
-    super.tap do |i|
-      i.delete :attachments if attachment_filenames.empty?
-      i.delete :payment_amount unless target.payment.present?
+    %i<submission_information attachments payment_amount>.tap do |arr|
+      arr.delete :attachments if attachment_filenames.empty?
+      arr.delete :payment_amount unless fee_to_pay?
     end
+  end
+
+  def payment_type
+    payment_failed? ? :payment_not_processed : :normal
   end
 
   def attachment_filenames

--- a/app/services/jadu/claim.rb
+++ b/app/services/jadu/claim.rb
@@ -43,8 +43,20 @@ module Jadu
 
     def attachments
       @attachments ||= claim.attachments.reduce({}) do |o, a|
-        o.update a.filename => a.file.read
+        o.update filename(a) => a.file.read
       end
+    end
+
+    # CarrierWave::Uploader::Base#filename is totally broken, i.e. You can't get
+    # the filename unless you assigned that file to that particular instance.
+    # If you later query the DB and try to get the filename from that instance
+    # it will be nil.
+    #
+    # This method normalizes the file URL for file and S3 backends. S3 private
+    # URLs have query params so can't directly be use with File.basename.
+
+    def filename(attachment)
+      File.basename URI.parse(attachment.url).path
     end
   end
 end

--- a/app/views/claim_confirmations/show.html.slim
+++ b/app/views/claim_confirmations/show.html.slim
@@ -12,13 +12,23 @@ header.main-header
     section.content-section
       h2 = t('.what_happens_next.header')
       ol.numerical-list
-        - unless claim.remission_claimant_count.zero?
+        - if confirmation_presenter.payment_failed?
           li
-            p = t('.what_happens_next.one_html')
-            p= link_to t('.what_happens_next.one_link'), 'https://www.employmenttribunals.service.gov.uk/remissions', class: 'button'
+            p= p= t('.what_happens_next.payment_failed')
+        - if confirmation_presenter.remission_applicable?
+          li
+            p= t('.what_happens_next.apply_for_remission')
+            p= link_to t('.what_happens_next.remission_link_text'),
+            'https://www.employmenttribunals.service.gov.uk/remissions',
+            class: 'button'
+          li
+            p= t('.what_happens_next.next_steps_remission')
 
-        li: p= t('.what_happens_next.two')
-        li: p= t('.what_happens_next.three')
+        -else
+          li
+            p= t('.what_happens_next.send_to_respondent')
+          li
+            p= t('.what_happens_next.next_steps')
 
       table.confirmation-table
         caption = t('.submission_details.header')

--- a/config/locales/claim_confirmation.en.yml
+++ b/config/locales/claim_confirmation.en.yml
@@ -10,14 +10,25 @@ en:
 
       what_happens_next:
         header: What happens next
-        one_html: You must apply for fee remission <b>within 7 days</b>, or your claim may be rejected. If you’ren’t eligible, you’ll have to pay the full amount.
-        one_link: Apply for fee remission
-        two: A judge will review your claim to make sure your it can be heard by an employment tribunal.
-        three: The person you’re making a claim against (respondent) will receive a copy of your claim. They will have 28 days to reply.
+        payment_failed: We’ll contact you within 5 working days to arrange payment.
+        apply_for_remission: |
+          You have said you want to apply for fee remission.
+          You must apply within 7 days, or your claim may be rejected.
+        remission_link_text: Apply for fee remission
+        send_to_respondent: |
+          A copy of the claim will be sent to the respondent.
+          They’ll have 28 days to reply.
+        next_steps: |
+          We’ll contact you when we’ve sent your claim to the respondent and
+          explain the next steps.
+        next_steps_remission: |
+          We’ll review your claim for remission and contact you to explain the
+          next steps.  
 
       download_application:
         header: Download your claim
-        link_html: <a href="%{href}" target="%{target}">Save a copy</a> for your records
+        link_html: |
+          <a href="%{href}" target="%{target}">Save a copy</a> for your records
 
       submission_details:
         header: Submission details
@@ -27,7 +38,9 @@ en:
         submission_without_office: Submitted %{date}
         submission_with_office: Submitted %{date} to tribunal office %{office}
 
-      print_link_html: <a href="javascript:window.print(0);">Print this page</a> for your records
+      print_link_html: |
+        <a href="javascript:window.print(0);">Print this page</a> for your
+        records
       unprocessable_payment: Unable to process payment
 
       pel_info: |

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
       Rack::Test::UploadedFile.new 'spec/support/files/file.csv'
     end
 
-    fee_group_reference { "%010d00" % rand(9999999999) }
+    fee_group_reference "511234567800"
 
     claim_details       'I am sad'
     other_claim_details 'Really sad'
@@ -30,7 +30,14 @@ FactoryGirl.define do
     pay_claims             %i<redundancy notice holiday arrears other>
     desired_outcomes       %i<compensation_only tribunal_recommendation>
 
+    password 'lollolol'
+
     submitted_at { Time.now }
+
+    trait :not_submitted do
+      submitted_at nil
+      state        'created'
+    end
 
     trait :without_additional_claimants_csv do
       additional_claimants_csv nil
@@ -67,6 +74,16 @@ FactoryGirl.define do
       remission_claimant_count 2
       payment nil
       after(:create) { |claim| create_list :claimant, 2, claim: claim }
+    end
+
+    trait :no_fee_group_reference do
+      office nil
+      fee_group_reference ""
+    end
+
+    trait :no_attachments do
+      additional_information_rtf nil
+      additional_claimants_csv nil
     end
   end
 

--- a/spec/features/confirmation_page_spec.rb
+++ b/spec/features/confirmation_page_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+feature 'Confirmation page' do
+  include FormMethods
+
+  before do
+    visit returning_user_session_path
+    fill_in_return_form claim.reference, 'lollolol'
+
+    visit claim_review_path
+    click_button 'Submit'
+  end
+
+  around do |example|
+    travel_to(Time.new 2014) { example.run }
+  end
+
+  context 'when payment fails' do
+    let(:claim) do
+      create :claim, :not_submitted, :no_fee_group_reference, :payment_no_remission_payment_failed
+    end
+
+    scenario 'viewing the confirmation page' do
+      expect(page).to have_text 'We’ll contact you within 5 working days to arrange payment.'
+      expect(page).to have_text 'Issue fee paid' 'Unable to process payment'
+    end
+  end
+
+  context 'when payment is successful' do
+    let(:claim) do
+      create :claim, :not_submitted, :payment_no_remission_payment_failed
+    end
+
+    before { complete_payment }
+
+    scenario 'viewing the confirmation page' do
+      expect(page).to_not have_text 'We’ll contact you within 5 working days to arrange payment.'
+      expect(page).to_not have_link 'Apply for fee remission'
+
+      expect(page).to have_text 'Claim submitted' 'Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU'
+      expect(page).to have_text 'Issue fee paid' '£250.00'
+      expect(page).to_not have_text 'If you have any questions, contact the Public Enquiry Line'
+    end
+  end
+
+  context 'single claimant' do
+    context 'when remission is sought' do
+      let(:claim) { create :claim, :not_submitted, :remission_only }
+
+      scenario 'viewing the confirmation page' do
+        expect(page).to have_text 'You have said you want to apply for fee remission. You must apply within 7 days, or your claim may be rejected.'
+        expect(page).to have_link 'Apply for fee remission'
+        expect(page).to have_text 'We’ll review your claim for remission and contact you to explain the next steps.'
+
+        expect(page).to have_text 'Claim submitted'
+        expect(page).to_not have_text 'Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU'
+
+        expect(page).to_not have_text 'Issue fee paid'
+
+        expect(page).to have_text 'If you have any questions, contact the Public Enquiry Line'
+
+      end
+    end
+  end
+
+  context 'multiple claimants' do
+    context 'when partial remission is sought' do
+      let(:claim) do
+        create :claim, :not_submitted, :group_payment_with_remission_payment_failed
+      end
+
+      before { complete_payment }
+
+      scenario 'viewing the confirmation page' do
+        expect(page).to have_text 'You have said you want to apply for fee remission. You must apply within 7 days, or your claim may be rejected.'
+        expect(page).to have_link 'Apply for fee remission'
+        expect(page).to have_text 'We’ll review your claim for remission and contact you to explain the next steps.'
+
+        expect(page).to have_text 'Issue fee paid' '£250.00'
+        expect(page).to have_text 'If you have any questions, contact the Public Enquiry Line'
+      end
+    end
+  end
+end

--- a/spec/features/session_expiry_spec.rb
+++ b/spec/features/session_expiry_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 feature 'Session Expiry', type: :feature do
   include FormMethods
-  include ActiveSupport::Testing::TimeHelpers
 
   let(:session_expiry_time) { 1.hours.from_now + 1.second }
 

--- a/spec/features/xml_generation_spec.rb
+++ b/spec/features/xml_generation_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 feature 'XML Generation', type: :feature do
-  include ActiveSupport::Testing::TimeHelpers
-
   before(:each)   { travel_to(Date.new 2014, 9, 29) }
 
   let(:claim)     { create :claim }

--- a/spec/models/jadu_xml/document_id_spec.rb
+++ b/spec/models/jadu_xml/document_id_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe JaduXml::DocumentId, type: :model do
-  include ActiveSupport::Testing::TimeHelpers
-
   before(:each) { travel_to Date.new(2014, 9, 29) }
 
   its(:name)    { is_expected.to eq "ETFeesEntry" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,8 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.after do |example|
     if example.metadata[:type] == :feature && example.exception.present?
       # Uncomment to autoload failed capybara tests in the browser


### PR DESCRIPTION
Show different copy for different application states, e.g. remission,
normal, partial remission, payment failure, etc.