### PR TITLE
moved cookie message to somewhere sensible

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -22,7 +22,7 @@
     javascript:
         document.body.className = document.body.className.replace('js-enabled','');
 
-= render partial: 'shared/cookie_message'
+  = render partial: 'shared/cookie_message'
 
 - content_for :footer_support_links do
   li= link_to "Guide", guide_path


### PR DESCRIPTION
cookie message was getting rendered before the doctype. Chrome is forgiving, but I wouldn't put it past IE to go all bonkers over it.