### PR TITLE
Fix AcasPresenter

### DIFF
--- a/app/presenters/jadu_xml/acas_presenter.rb
+++ b/app/presenters/jadu_xml/acas_presenter.rb
@@ -5,7 +5,7 @@ module JaduXml
       "acas_has_no_jurisdiction"                        => "outside_acas",
       "employer_contacted_acas"                         => "employer_contacted_acas",
       "interim_relief"                                  => "interim_relief",
-      "claim_against_security_or_intelligence_services" => "claim_targets"
+      "claim_against_security_services"                 => "claim_targets"
     }.freeze
 
     property :acas_early_conciliation_certificate_number, as: "Number"

--- a/spec/presenters/jadu_xml/acas_presenter_spec.rb
+++ b/spec/presenters/jadu_xml/acas_presenter_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe JaduXml::AcasPresenter, type: :presenter do
   end
 
   describe "#exemption_code" do
+    it 'maps all exemption types' do
+      RespondentForm::NO_ACAS_REASON.each do |reason|
+        mock_acas_reason(reason)
+        expect(subject.exemption_code).to be_present
+      end
+    end
+
     context "respondents no acas number reason returns" do
       context "joint_claimant_has_acas_number" do
         before { mock_acas_reason("joint_claimant_has_acas_number") }
@@ -31,8 +38,8 @@ RSpec.describe JaduXml::AcasPresenter, type: :presenter do
         its(:exemption_code) { is_expected.to eq "interim_relief" }
       end
 
-      context "claim_against_security_or_intelligence_services" do
-        before { mock_acas_reason("claim_against_security_or_intelligence_services") }
+      context "claim_against_security_services" do
+        before { mock_acas_reason("claim_against_security_services") }
         its(:exemption_code) { is_expected.to eq "claim_targets" }
       end
     end


### PR DESCRIPTION
The mapping for security services had been changed and didn't match
up with the presenter. Fixed and added a regression test to catch
in the future.