### PR TITLE
Setup deadletter queue

### DIFF
--- a/lib/tasks/sneakers.rake
+++ b/lib/tasks/sneakers.rake
@@ -12,7 +12,11 @@ namespace :sneakers do
 
     workers = ActiveJob::Base.subclasses.map do |klass|
       klass.const_set("Wrapper", Class.new(ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper) do
-        from_queue klass.queue_name
+        from_queue klass.queue_name,
+                     :headers => {
+                       :'x-dead-letter-exchange' => "#{klass.queue_name}-retry"
+                     }
+
       end)
     end
 


### PR DESCRIPTION
If there's an error, the message goes into the -retry queue, retries are managed by sneakers. If the max retries fail the message is sent to the -error queue.