### PR TITLE
Check memorable word is present before trying to authenticate

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -57,6 +57,10 @@ class Claim < ActiveRecord::Base
     find_by(application_reference: normalized)
   end
 
+  def authenticate(password)
+    password_digest? && super
+  end
+
   def alleges_discrimination_or_unfair_dismissal?
     discrimination_claims.any? || is_unfair_dismissal?
   end

--- a/spec/features/save_and_return_spec.rb
+++ b/spec/features/save_and_return_spec.rb
@@ -67,4 +67,14 @@ feature 'Save and Return' do
     expect(page).to have_text(claim_heading_for(:claimant))
     expect(page).to have_field('Last name', with: 'Wrigglesworth')
   end
+
+  context 'memorable word not set' do
+    scenario 'returning to an existing application' do
+      start_claim
+      end_session
+      fill_in_return_form Claim.last.reference, 'memorable word was not set'
+
+      expect(page).to have_text 'Return to your claim'
+    end
+  end
 end


### PR DESCRIPTION
fixes #579 

*shoulda matcher perfoms valid `authenticates` checks with the `have_secure_password` matcher hence no test added or changed in the claim spec 