### PR TITLE
Fix fee group reference request behaviour

### DIFF
--- a/spec/models/respondent_spec.rb
+++ b/spec/models/respondent_spec.rb
@@ -28,49 +28,64 @@ RSpec.describe Respondent, :type => :model do
       let(:claim) { Claim.new }
       subject     { described_class.new claim: claim }
 
-      context 'when the respondent has one address' do
-        context 'and the post code has changed' do
-          before { subject.address.post_code = 'W1F 7JG' }
-
-          it 'enqueues a fee group reference request with that post code' do
-            expect(FeeGroupReferenceJob).to receive(:perform_later).with(claim, 'W1F 7JG')
-
-            subject.save
-          end
+      context 'when primary_respondent? is false' do
+        before do
+          subject.assign_attributes primary_respondent: false, address_post_code: 'W1F 7JG'
         end
 
-        context 'and the post code has not changed' do
-          before { subject.address.update post_code: 'W1F 7JG' }
-
-          it 'does not enqueue a fee group reference request' do
-            expect(FeeGroupReferenceJob).not_to receive(:perform_later)
-
-            subject.save
-          end
+        it 'does not enqueue a fee group reference request' do
+          expect(FeeGroupReferenceJob).not_to receive(:perform_later)
+          subject.save
         end
       end
 
-      context 'when the respondent has a secondary address' do
-        context 'and the post code has changed' do
-          before do
-            subject.address.post_code = 'W1F 7JG'
-            subject.work_address.post_code = 'SW1A 1AA'
+      context 'when primary_respondent? is true' do
+        before { subject.primary_respondent = true }
+
+        context 'when the respondent has one address' do
+          context 'and the post code has changed' do
+            before { subject.address.post_code = 'W1F 7JG' }
+
+            it 'enqueues a fee group reference request with that post code' do
+              expect(FeeGroupReferenceJob).to receive(:perform_later).with(claim, 'W1F 7JG')
+
+              subject.save
+            end
           end
 
-          it 'enqueues a fee group reference request with that post code' do
-            expect(FeeGroupReferenceJob).to receive(:perform_later).with(claim, 'SW1A 1AA')
+          context 'and the post code has not changed' do
+            before { subject.address.update post_code: 'W1F 7JG' }
 
-            subject.save
+            it 'does not enqueue a fee group reference request' do
+              expect(FeeGroupReferenceJob).not_to receive(:perform_later)
+
+              subject.save
+            end
           end
         end
 
-        context 'and the post code has not changed' do
-          before { subject.work_address.update post_code: 'SW1A 1AA' }
+        context 'when the respondent has a secondary address' do
+          context 'and the post code has changed' do
+            before do
+              subject.address.post_code = 'W1F 7JG'
+              subject.work_address.post_code = 'SW1A 1AA'
+            end
 
-          it 'does not enqueue a fee group reference request' do
-            expect(FeeGroupReferenceJob).not_to receive(:perform_later)
+            it 'enqueues a fee group reference request with that post code' do
+              expect(FeeGroupReferenceJob).to receive(:perform_later).with(claim, 'SW1A 1AA')
 
-            subject.save
+              subject.save
+            end
+          end
+
+          context 'and the post code has not changed' do
+            before { subject.work_address.update post_code: 'SW1A 1AA' }
+
+            it 'does not enqueue a fee group reference request' do
+              expect(FeeGroupReferenceJob).not_to receive(:perform_later)
+
+              subject.save
+            end
           end
         end
       end


### PR DESCRIPTION
FGR requests should only be made by the primary respondent. The
request code was written before multiple repsondents was implemented.
This commit ensures FGR requests are only made by the primary
respondent.