### PR TITLE
Lock Dotenv at earlier version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'binding_of_caller'
   gem 'capybara'
   gem 'codeclimate-test-reporter', require: nil
-  gem 'dotenv-rails'
+  gem 'dotenv-rails', '0.11.1'
   gem 'factory_girl_rails'
   gem 'guard-livereload'
   gem 'launchy'


### PR DESCRIPTION
We need it for env specific .env files. Can't wait til we don't have to use this anymore.