### PR TITLE
Admin dashboard for inflight metadata inspection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ end
 
 gem 'webmock', group: :test
 
+gem 'activeadmin', github: 'activeadmin', ref: '156877'
 gem 'base32_pure'
 gem 'bcrypt'
 gem 'bitmask_attributes'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,23 @@
 GIT
+  remote: git://github.com/activeadmin/activeadmin.git
+  revision: 15687751fa9ff637a7b39aae36d6b35abdb8fed4
+  ref: 156877
+  specs:
+    activeadmin (1.0.0.pre)
+      arbre (~> 1.0, >= 1.0.2)
+      bourbon
+      coffee-rails
+      formtastic (~> 3.1)
+      formtastic_i18n
+      inherited_resources (~> 1.6)
+      jquery-rails
+      jquery-ui-rails (~> 5.0)
+      kaminari (~> 0.15)
+      rails (>= 3.2, < 5.0)
+      ransack (~> 1.3)
+      sass-rails
+
+GIT
   remote: git://github.com/carrierwaveuploader/carrierwave.git
   revision: 56873b07105396e0f1cfdd5e38be930dc3dcd362
   ref: 56873b07105396e0f1cfdd5e38be930dc3dcd362
@@ -56,6 +75,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.6)
     amq-protocol (1.9.2)
+    arbre (1.0.3)
+      activesupport (>= 3.0.0)
     arel (6.0.0)
     ast (2.0.0)
     astrolabe (1.3.0)
@@ -75,6 +96,9 @@ GEM
       debug_inspector (>= 0.0.1)
     bitmask_attributes (1.0.0)
       activerecord (>= 3.1)
+    bourbon (4.1.1)
+      sass (~> 3.3)
+      thor
     browserify-rails (0.5.1)
       sprockets (~> 2.0)
     builder (3.2.2)
@@ -227,6 +251,9 @@ GEM
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
+    formtastic (3.1.3)
+      actionpack (>= 3.2.13)
+    formtastic_i18n (0.1.1)
     globalid (0.3.0)
       activesupport (>= 4.1.0)
     govuk_frontend_toolkit (2.0.0)
@@ -245,6 +272,9 @@ GEM
       em-websocket (~> 0.5)
       guard (~> 2.8)
       multi_json (~> 1.8)
+    has_scope (0.6.0.rc)
+      actionpack (>= 3.2, < 5)
+      activesupport (>= 3.2, < 5)
     hike (1.2.3)
     hitimes (1.2.2)
     http_parser.rb (0.6.0)
@@ -254,6 +284,11 @@ GEM
     i18n (0.7.0)
     ice_nine (0.11.1)
     inflecto (0.0.2)
+    inherited_resources (1.6.0)
+      actionpack (>= 3.2, < 5)
+      has_scope (~> 0.6.0.rc)
+      railties (>= 3.2, < 5)
+      responders
     ipaddress (0.8.0)
     jbuilder (2.2.6)
       activesupport (>= 3.0.0, < 5)
@@ -262,7 +297,12 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.3)
+      railties (>= 3.2.16)
     json (1.8.2)
+    kaminari (0.16.2)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -300,6 +340,8 @@ GEM
       ast (>= 1.1, < 3.0)
     pdf-forms (0.6.0)
     pg (0.18.1)
+    polyamorous (1.1.0)
+      activerecord (>= 3.0)
     powerpack (0.0.9)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -342,6 +384,12 @@ GEM
     rainbow (2.0.0)
     raindrops (0.13.0)
     rake (10.4.2)
+    ransack (1.6.3)
+      actionpack (>= 3.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      i18n
+      polyamorous (~> 1.1)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -464,6 +512,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activeadmin!
   awesome_print
   base32_pure
   bcrypt

--- a/app/admin/claim.rb
+++ b/app/admin/claim.rb
@@ -1,0 +1,48 @@
+ActiveAdmin.register Claim do
+  filter :submitted_at
+
+  # no edit, destory, create, etc
+  config.clear_action_items!
+  actions :index, :show
+
+  controller { defaults finder: :find_by_reference }
+
+  # Index page
+  index download_links: false do
+    column :reference do |claim|
+      link_to claim.reference, admin_claim_path(claim.reference)
+    end
+
+    column :fee_group_reference
+
+    column(:missing_payment) do |claim|
+      if claim.immutable? && claim.fee_to_pay? && !claim.payment_present?
+        'Yes'
+      else
+        'N/A'
+      end
+    end
+
+    column(:state) { |claim| claim.state.humanize }
+  end
+
+  # Show
+  show title: :reference do
+    panel 'Metadata' do
+      attributes_table_for claim do
+        row('Submitted to JADU') { |c| c.submitted? ? c.submitted_at : 'No' }
+        row('Payment required')  { |c| c.fee_to_pay? ? 'Yes' : 'No' }
+        row('Payment received')  { |c| c.payment_present? ? 'Yes' : 'No' }
+      end
+    end
+
+    panel 'Events' do
+      table_for claim.events do
+        column :event
+        column :actor
+        column :message
+        column :created_at
+      end
+    end
+  end
+end

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,0 +1,1 @@
+#= require active_admin/base

--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -1,0 +1,17 @@
+// SASS variable overrides must be declared before loading up Active Admin's styles.
+//
+// To view the variables that Active Admin provides, take a look at
+// `app/assets/stylesheets/active_admin/mixins/_variables.css.scss` in the
+// Active Admin source.
+//
+// For example, to change the sidebar width:
+// $sidebar-width: 242px;
+
+// Active Admin's got SASS!
+@import "active_admin/mixins";
+@import "active_admin/base";
+
+// Overriding any non-variable SASS must be done after the fact.
+// For example, to change the default status-tag color:
+//
+//   .status_tag { background: #6090DB; }

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,0 +1,234 @@
+ActiveAdmin.setup do |config|
+  # == Site Title
+  #
+  # Set the title that is displayed on the main layout
+  # for each of the active admin pages.
+  #
+  config.site_title = "ET Fees Claim Metadata"
+
+  # Set the link url for the title. For example, to take
+  # users to your main site. Defaults to no link.
+  #
+  # config.site_title_link = "/"
+
+  # Set an optional image to be displayed for the header
+  # instead of a string (overrides :site_title)
+  #
+  # Note: Aim for an image that's 21px high so it fits in the header.
+  #
+  # config.site_title_image = "logo.png"
+
+  # == Default Namespace
+  #
+  # Set the default namespace each administration resource
+  # will be added to.
+  #
+  # eg:
+  #   config.default_namespace = :hello_world
+  #
+  # This will create resources in the HelloWorld module and
+  # will namespace routes to /hello_world/*
+  #
+  # To set no namespace by default, use:
+  #   config.default_namespace = false
+  #
+  # Default:
+  # config.default_namespace = :admin
+  #
+  # You can customize the settings for each namespace by using
+  # a namespace block. For example, to change the site title
+  # within a namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.site_title = "Custom Admin Title"
+  #   end
+  #
+  # This will ONLY change the title for the admin section. Other
+  # namespaces will continue to use the main "site_title" configuration.
+
+  # == User Authentication
+  #
+  # Active Admin will automatically call an authentication
+  # method in a before filter of all controller actions to
+  # ensure that there is a currently logged in admin user.
+  #
+  # This setting changes the method which Active Admin calls
+  # within the application controller.
+  # config.authentication_method = :authenticate_admin_user!
+  config.authentication_method = false
+  config.current_user_method   = false
+
+  # == User Authorization
+  #
+  # Active Admin will automatically call an authorization
+  # method in a before filter of all controller actions to
+  # ensure that there is a user with proper rights. You can use
+  # CanCanAdapter or make your own. Please refer to documentation.
+  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+
+  # In case you prefer Pundit over other solutions you can here pass
+  # the name of default policy class. This policy will be used in every
+  # case when Pundit is unable to find suitable policy.
+  # config.pundit_default_policy = "MyDefaultPunditPolicy"
+
+  # You can customize your CanCan Ability class name here.
+  # config.cancan_ability_class = "Ability"
+
+  # You can specify a method to be called on unauthorized access.
+  # This is necessary in order to prevent a redirect loop which happens
+  # because, by default, user gets redirected to Dashboard. If user
+  # doesn't have access to Dashboard, he'll end up in a redirect loop.
+  # Method provided here should be defined in application_controller.rb.
+  # config.on_unauthorized_access = :access_denied
+
+  # == Current User
+  #
+  # Active Admin will associate actions with the current
+  # user performing them.
+  #
+  # This setting changes the method which Active Admin calls
+  # (within the application controller) to return the currently logged in user.
+
+  # == Logging Out
+  #
+  # Active Admin displays a logout link on each screen. These
+  # settings configure the location and method used for the link.
+  #
+  # This setting changes the path where the link points to. If it's
+  # a string, the strings is used as the path. If it's a Symbol, we
+  # will call the method to return the path.
+  #
+  # Default:
+  config.logout_link_path = :destroy_admin_user_session_path
+
+  # This setting changes the http method used when rendering the
+  # link. For example :get, :delete, :put, etc..
+  #
+  # Default:
+  # config.logout_link_method = :get
+
+  # == Root
+  #
+  # Set the action to call for the root path. You can set different
+  # roots for each namespace.
+  #
+  # Default:
+  config.root_to = 'claims#index'
+
+  # == Admin Comments
+  #
+  # This allows your users to comment on any resource registered with Active Admin.
+  #
+  # You can completely disable comments:
+  config.comments = false
+  #
+  # You can disable the menu item for the comments index page:
+  # config.show_comments_in_menu = false
+  #
+  # You can change the name under which comments are registered:
+  # config.comments_registration_name = 'AdminComment'
+
+  # == Batch Actions
+  #
+  # Enable and disable Batch Actions
+  #
+  config.batch_actions = true
+
+  # == Controller Filters
+  #
+  # You can add before, after and around filters to all of your
+  # Active Admin resources and pages from here.
+  #
+  # config.before_filter :do_something_awesome
+
+  # == Setting a Favicon
+  #
+  # config.favicon = '/assets/favicon.ico'
+
+  # == Removing Breadcrumbs
+  #
+  # Breadcrumbs are enabled by default. You can customize them for individual
+  # resources or you can disable them globally from here.
+  #
+  # config.breadcrumb = false
+
+  # == Register Stylesheets & Javascripts
+  #
+  # We recommend using the built in Active Admin layout and loading
+  # up your own stylesheets / javascripts to customize the look
+  # and feel.
+  #
+  # To load a stylesheet:
+  #   config.register_stylesheet 'my_stylesheet.css'
+  #
+  # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
+  #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
+  #
+  # To load a javascript file:
+  #   config.register_javascript 'my_javascript.js'
+
+  # == CSV options
+  #
+  # Set the CSV builder separator
+  # config.csv_options = { col_sep: ';' }
+  #
+  # Force the use of quotes
+  # config.csv_options = { force_quotes: true }
+
+  # == Menu System
+  #
+  # You can add a navigation menu to be used in your application, or configure a provided menu
+  #
+  # To change the default utility navigation to show a link to your website & a logout btn
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :utility_navigation do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #       admin.add_logout_button_to_menu menu
+  #     end
+  #   end
+  #
+  # If you wanted to add a static menu item to the default menu provided:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :default do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #     end
+  #   end
+
+  # == Download Links
+  #
+  # You can disable download links on resource listing pages,
+  # or customize the formats shown per namespace/globally
+  #
+  # To disable/customize for the :admin namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #
+  #     # Disable the links entirely
+  #     admin.download_links = false
+  #
+  #     # Only show XML & PDF options
+  #     admin.download_links = [:xml, :pdf]
+  #
+  #     # Enable/disable the links based on block
+  #     #   (for example, with cancan)
+  #     admin.download_links = proc { can?(:view_download_links) }
+  #
+  #   end
+
+  # == Pagination
+  #
+  # Pagination is enabled by default for all resources.
+  # You can control the default per page count for all resources here.
+  #
+  # config.default_per_page = 30
+
+  # == Filters
+  #
+  # By default the index screen includes a "Filters" sidebar on the right
+  # hand side with a filter for each attribute of the registered model.
+  # You can enable or disable them for all resources here.
+  #
+  # config.filters = true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,10 @@ Rails.application.routes.draw do
         get :expired
       end
     end
+
+    constraints(ip: /81\.134\.202\.290|127\.0\.0\.1/) do
+      ActiveAdmin.routes(self)
+    end
   end
 
   get '/apply' => 'claims#new'

--- a/db/migrate/20150128174612_create_active_admin_comments.rb
+++ b/db/migrate/20150128174612_create_active_admin_comments.rb
@@ -1,0 +1,19 @@
+class CreateActiveAdminComments < ActiveRecord::Migration
+  def self.up
+    create_table :active_admin_comments do |t|
+      t.string :namespace
+      t.text   :body
+      t.string :resource_id,   null: false
+      t.string :resource_type, null: false
+      t.references :author, polymorphic: true
+      t.timestamps
+    end
+    add_index :active_admin_comments, [:namespace]
+    add_index :active_admin_comments, [:author_type, :author_id]
+    add_index :active_admin_comments, [:resource_type, :resource_id]
+  end
+
+  def self.down
+    drop_table :active_admin_comments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150127155238) do
+ActiveRecord::Schema.define(version: 20150128174612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_admin_comments", force: :cascade do |t|
+    t.string   "namespace"
+    t.text     "body"
+    t.string   "resource_id",   null: false
+    t.string   "resource_type", null: false
+    t.integer  "author_id"
+    t.string   "author_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "active_admin_comments", ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
+  add_index "active_admin_comments", ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
+  add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
 
   create_table "addresses", force: :cascade do |t|
     t.string   "building",         limit: 255


### PR DESCRIPTION
Couple of things:

- There are no user accounts, anyone on the VPN can access this page. It's a 404 if they're not on the VPM.
- Pending the addition of user accounts the ability to change or otherwise interfere with claims is disabled.
- Similarly it is not possible to view any claimant or claim information, just metadata.