### PR TITLE
Render errors on base

### DIFF
--- a/app/assets/stylesheets/forms/_form-errors.scss
+++ b/app/assets/stylesheets/forms/_form-errors.scss
@@ -14,6 +14,9 @@
 .validation-summary{
   background:lighten($error-colour, 45%);
   margin: $gutter 0;
+  .main-content & {
+    margin-top:0;
+  }
   h2{
     @extend .heading-medium;
     margin:0;

--- a/app/form_builder/et_fees/error_notification.rb
+++ b/app/form_builder/et_fees/error_notification.rb
@@ -2,17 +2,19 @@ module ETFees
   class ErrorNotification < SimpleForm::ErrorNotification
     def render
       if has_errors?
-        template.render(
-          partial: 'shared/error_notification',
-          locals: { message: error_message, errors: ids_and_errors }
-        )
+        template.render partial: 'shared/error_notification',
+          locals: { message: message }
       end
     end
 
     private
 
-    def ids_and_errors
-      errors.map { |attr, err| ["##{object_name}_#{attr}", err] }
+    def message
+      if errors[:base].any?
+        errors[:base].to_sentence
+      else
+        error_message
+      end
     end
   end
 end

--- a/app/views/shared/_error_notification.html.slim
+++ b/app/views/shared/_error_notification.html.slim
@@ -1,3 +1,3 @@
-#error-summary.validation-summary.group role="alert" tabindex='0' aria={ labelledby: 'error-heading', describedby: 'error-message' } 
+#error-summary.validation-summary.group role="alert" tabindex='0' aria={ labelledby: 'error-heading', describedby: 'error-message' }
   h2#error-heading = t 'aria.error_summary'
   p#error-message = message

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -7,7 +7,7 @@ header.main-header role="banner"
 
   .main-content
     = simple_form_for user_session, url: user_session_path do |f|
-      = f.error :base
+      = f.error_notification
 
       fieldset
         legend = t('.subheader')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -389,6 +389,8 @@ en:
       header: Return to your claim
       subheader: Enter your details below
       hint_html: Don’t have these details? <a href="%{path}">Start a new claim</a>.
+    create:
+      header: Return to your claim
     reminder:
       header: Claim saved
       legend: Return to complete your claim


### PR DESCRIPTION
At this point we only use this on the user sessions page. The behaviour
is if there are errors on base show the errors in the notification
header, else show the fix errors below message.