### PR TITLE
Allow pdf to be generated when payment is required

### DIFF
--- a/app/jobs/pdf_generation_job.rb
+++ b/app/jobs/pdf_generation_job.rb
@@ -1,0 +1,7 @@
+class PdfGenerationJob < ActiveJob::Base
+  queue_as :pdf_generation
+
+  def perform(claim)
+    claim.generate_pdf!
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -87,7 +87,6 @@ class Claim < ActiveRecord::Base
     super
   end
 
-  # TODO: validate claim against JADU XSD
   def submittable?
     %i<primary_claimant primary_respondent>.all? do |relation|
       send(relation).present?
@@ -119,8 +118,10 @@ class Claim < ActiveRecord::Base
   end
 
   def generate_pdf!
-    PdfFormBuilder.build(self) { |file| self.update pdf: file }
-    create_event Event::PDF_GENERATED
+    if pdf_blank?
+      PdfFormBuilder.build(self) { |file| self.update pdf: file }
+      create_event Event::PDF_GENERATED
+    end
   end
 
   def attachments

--- a/app/models/claim/finite_state_machine.rb
+++ b/app/models/claim/finite_state_machine.rb
@@ -34,6 +34,10 @@ class Claim::FiniteStateMachine
 
     after_transition do: ->(claim) { claim.save! }
 
+    after_transition :created => :payment_required, do: ->(machine) do
+      PdfGenerationJob.perform_later machine.claim
+    end
+
     after_transition any => :enqueued_for_submission, do: ->(machine) do
       claim = machine.claim
 

--- a/spec/jobs/pdf_generation_job_spec.rb
+++ b/spec/jobs/pdf_generation_job_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe PdfGenerationJob, type: :job do
+  let(:claim)  { object_double Claim.new }
+
+  describe '#perform' do
+    it 'generates the pdf' do
+      expect(claim).to receive(:generate_pdf!)
+      subject.perform(claim)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Perform pdf generation asynchronously when payment is required(so we can hit up the pdf link on the payment page)
- [x] Ensure PDF is only generated once
- [x] Exchange config on RMQ @mattmb 