### PR TITLE
Ensure save & complete later is visible when adding more claimants manually

### DIFF
--- a/app/helpers/signout_visibility_helper.rb
+++ b/app/helpers/signout_visibility_helper.rb
@@ -1,14 +1,13 @@
 module SignoutVisibilityHelper
   def show_signout?
-    return unless action_name == 'show'
-
     case controller_name
-    when 'claims'
-      params[:page] != 'application-number'
-    when *%w<claim_reviews payments multiples>
-      true
-    else
-      false
+    when 'claims'                              then applicable_claim_page?
+    when *%w<claim_reviews payments multiples> then true
+    else false
     end
+  end
+
+  private def applicable_claim_page?
+    action_name != 'new' && params[:page] != 'application-number'
   end
 end

--- a/spec/features/multiple_claimants_spec.rb
+++ b/spec/features/multiple_claimants_spec.rb
@@ -74,6 +74,14 @@ feature 'Multiple claimants' do
 
       expect(claim.secondary_claimants.pluck(:first_name)).to match_array %w<Persephone Pegasus>
     end
+
+    scenario 'a user can still save & complete later' do
+      expect(page).to have_signout_button
+
+      click_button "Add more claimants"
+
+      expect(page).to have_signout_button
+    end
   end
 
   describe 'destroying claimants' do


### PR DESCRIPTION
The signout helper now supports the the `update` action when requests go through the multiples controller