### PR TITLE
Compile non digested assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,6 @@ gem 'susy'
 gem 'compass'
 gem 'virtus'
 gem 'zendesk_api'
+# This gem ensures rails 4 also builds a non-digest version of the assets
+# so that static pages can refer to them.
+gem "non-stupid-digest-assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,7 @@ GEM
     net-ssh (2.9.2)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
+    non-stupid-digest-assets (1.0.4)
     notiffany (0.0.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -549,6 +550,7 @@ DEPENDENCIES
   launchy
   logstasher
   moj_template (= 0.18.0)
+  non-stupid-digest-assets
   pdf-forms
   pg
   pry-byebug


### PR DESCRIPTION
Uses this gem:
https://github.com/alexspeller/non-stupid-digest-assets

To fix this issue:
https://github.com/rails/sprockets-rails/issues/49

@dan-palmer I think this is the best solution, it seems to create a copy which is better than symlinking if we end up hosting the assets somewhere else.