### PR TITLE
Move additional information rtf upload to claim details page

### DIFF
--- a/app/forms/additional_information_form.rb
+++ b/app/forms/additional_information_form.rb
@@ -1,34 +1,19 @@
 class AdditionalInformationForm < Form
   boolean   :has_miscellaneous_information
+  attribute :miscellaneous_information, String
 
-  attribute :miscellaneous_information,         String
-  attribute :additional_information_rtf,        AttachmentUploader
-  attribute :remove_additional_information_rtf, Boolean
-
-  before_validation :remove_additional_information_rtf!, if: :remove_additional_information_rtf
-  before_validation :reset_miscellaneous_information!, unless: :has_miscellaneous_information?
-
-  delegate :additional_information_rtf_cache, :additional_information_rtf_cache=,
-    :remove_additional_information_rtf!, to: :target
+  before_validation :reset_miscellaneous_information!,
+    unless: :has_miscellaneous_information?
 
   validates :miscellaneous_information, length: { maximum: 5000 }
-  validates :additional_information_rtf, content_type: {
-    in: %w<text/rtf>, message: I18n.t('errors.messages.rtf')
-  }
-
-  def has_additional_information_rtf?
-    resource.additional_information_rtf_file.present?
-  end
 
   def has_miscellaneous_information
     self.has_miscellaneous_information = miscellaneous_information.present?
   end
 
-  def attachment_filename
-    CarrierwaveFilename.for additional_information_rtf
-  end
+  private
 
-  private def reset_miscellaneous_information!
+  def reset_miscellaneous_information!
     self.miscellaneous_information = nil
   end
 end

--- a/app/forms/claim_details_form.rb
+++ b/app/forms/claim_details_form.rb
@@ -1,11 +1,31 @@
 class ClaimDetailsForm < Form
-  attribute :claim_details,              String
-  attribute :other_known_claimant_names, String
+  attribute :claim_details,                     String
+  attribute :other_known_claimant_names,        String
+  attribute :additional_information_rtf,        AttachmentUploader
+  attribute :remove_additional_information_rtf, Boolean
+
+  before_validation :remove_additional_information_rtf!,
+    if: :remove_additional_information_rtf
+
+  delegate :additional_information_rtf_cache, :additional_information_rtf_cache=,
+    :remove_additional_information_rtf!, to: :target
 
   validates :claim_details, length: { maximum: 5000 }, presence: true
   validates :other_known_claimant_names, length: { maximum: 350 }
+  validates :additional_information_rtf, content_type: {
+    in: %w<text/rtf text/plain>,
+    message: I18n.t('errors.messages.rtf')
+  }
 
   boolean :other_known_claimants
+
+  def has_additional_information_rtf?
+    resource.additional_information_rtf_file.present?
+  end
+
+  def attachment_filename
+    CarrierwaveFilename.for additional_information_rtf
+  end
 
   def other_known_claimants
     @other_known_claimants ||= other_known_claimant_names?

--- a/app/forms/claim_details_form.rb
+++ b/app/forms/claim_details_form.rb
@@ -1,30 +1,30 @@
 class ClaimDetailsForm < Form
   attribute :claim_details,                     String
   attribute :other_known_claimant_names,        String
-  attribute :additional_information_rtf,        AttachmentUploader
-  attribute :remove_additional_information_rtf, Boolean
+  attribute :claim_details_rtf,        AttachmentUploader
+  attribute :remove_claim_details_rtf, Boolean
 
-  before_validation :remove_additional_information_rtf!,
-    if: :remove_additional_information_rtf
+  before_validation :remove_claim_details_rtf!,
+    if: :remove_claim_details_rtf
 
-  delegate :additional_information_rtf_cache, :additional_information_rtf_cache=,
-    :remove_additional_information_rtf!, to: :target
+  delegate :claim_details_rtf_cache, :claim_details_rtf_cache=,
+    :remove_claim_details_rtf!, to: :target
 
   validates :claim_details, length: { maximum: 5000 }, presence: true
   validates :other_known_claimant_names, length: { maximum: 350 }
-  validates :additional_information_rtf, content_type: {
+  validates :claim_details_rtf, content_type: {
     in: %w<text/rtf text/plain>,
     message: I18n.t('errors.messages.rtf')
   }
 
   boolean :other_known_claimants
 
-  def has_additional_information_rtf?
-    resource.additional_information_rtf_file.present?
+  def has_claim_details_rtf?
+    resource.claim_details_rtf_file.present?
   end
 
   def attachment_filename
-    CarrierwaveFilename.for additional_information_rtf
+    CarrierwaveFilename.for claim_details_rtf
   end
 
   def other_known_claimants

--- a/app/forms/claim_details_form.rb
+++ b/app/forms/claim_details_form.rb
@@ -1,8 +1,10 @@
 class ClaimDetailsForm < Form
-  attribute :claim_details,                     String
-  attribute :other_known_claimant_names,        String
-  attribute :claim_details_rtf,        AttachmentUploader
-  attribute :remove_claim_details_rtf, Boolean
+  attribute :claim_details,               String
+  attribute :other_known_claimant_names,  String
+  attribute :claim_details_rtf,           AttachmentUploader
+  attribute :remove_claim_details_rtf,    Boolean
+
+  boolean :other_known_claimants
 
   before_validation :remove_claim_details_rtf!,
     if: :remove_claim_details_rtf
@@ -10,14 +12,12 @@ class ClaimDetailsForm < Form
   delegate :claim_details_rtf_cache, :claim_details_rtf_cache=,
     :remove_claim_details_rtf!, to: :target
 
-  validates :claim_details, length: { maximum: 5000 }, presence: true
+  validates :claim_details, length: { maximum: 5000 },
+    presence: true, unless: -> { claim_details_rtf.present? }
   validates :other_known_claimant_names, length: { maximum: 350 }
   validates :claim_details_rtf, content_type: {
-    in: %w<text/rtf text/plain>,
-    message: I18n.t('errors.messages.rtf')
+    in: %w<text/rtf>, message: I18n.t('errors.messages.rtf')
   }
-
-  boolean :other_known_claimants
 
   def has_claim_details_rtf?
     resource.claim_details_rtf_file.present?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -92,6 +92,10 @@ class Claim < ActiveRecord::Base
     super.tap { update_column(:pdf, nil) }
   end
 
+  def remove_claim_details_rtf!
+    super.tap { update_column(:claim_details_rtf, nil) }
+  end
+
   def submittable?
     %i<primary_claimant primary_respondent>.all? do |relation|
       send(relation).present?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,6 +1,6 @@
 class Claim < ActiveRecord::Base
   has_secure_password validations: false
-  mount_uploader :additional_information_rtf, AttachmentUploader
+  mount_uploader :claim_details_rtf,          AttachmentUploader
   mount_uploader :additional_claimants_csv,   AttachmentUploader
   mount_uploader :pdf,                        ClaimPdfUploader
 
@@ -32,7 +32,7 @@ class Claim < ActiveRecord::Base
   has_one  :payment
 
   delegate :amount, :created_at, :reference, :present?, to: :payment, prefix: true, allow_nil: true
-  delegate :file, to: :additional_information_rtf, prefix: true
+  delegate :file, to: :claim_details_rtf, prefix: true
   delegate :file, to: :additional_claimants_csv, prefix: true
   delegate :file, :url, :present?, :blank?, to: :pdf, prefix: true
 

--- a/app/presenters/additional_information_presenter.rb
+++ b/app/presenters/additional_information_presenter.rb
@@ -2,8 +2,4 @@ class AdditionalInformationPresenter < Presenter
   def miscellaneous_information
     simple_format target.miscellaneous_information
   end
-
-  def attached_document
-    CarrierwaveFilename.for additional_information_rtf
-  end
 end

--- a/app/presenters/claim_details_presenter.rb
+++ b/app/presenters/claim_details_presenter.rb
@@ -6,4 +6,8 @@ class ClaimDetailsPresenter < Presenter
   def other_known_claimant_names
     simple_format target.other_known_claimant_names
   end
+
+  def attached_document
+    CarrierwaveFilename.for claim_details_rtf
+  end
 end

--- a/app/presenters/confirmation_presenter.rb
+++ b/app/presenters/confirmation_presenter.rb
@@ -43,7 +43,7 @@ class ConfirmationPresenter < Presenter
   end
 
   def attachment_filenames
-    [additional_information_rtf, additional_claimants_csv].map do |attachment|
+    [claim_details_rtf, additional_claimants_csv].map do |attachment|
       CarrierwaveFilename.for attachment
     end.compact
   end

--- a/app/views/claims/_additional_information.html.slim
+++ b/app/views/claims/_additional_information.html.slim
@@ -17,15 +17,3 @@ fieldset
     wrapper_html: { :class => 'toggle-content reveal-subscribe',
                     :'data-target' => 'main',
                     :'data-show-array' => 'true' }
-
-  = f.input :additional_information_rtf do
-    - if resource.has_additional_information_rtf?
-        = f.input :remove_additional_information_rtf, as: :boolean,
-          inline_label: t('.remove_additional_information_rtf',
-            file: resource.attachment_filename),
-          label: false
-
-    = f.input_field :additional_information_rtf, as: :file
-
-  = f.hidden_field :additional_information_rtf_cache
-  p.form-hint = t('.upload_limit')

--- a/app/views/claims/_claim_details.html.slim
+++ b/app/views/claims/_claim_details.html.slim
@@ -9,15 +9,14 @@ p= t('.upload_details')
   input_html: { rows: 30 }
 
 legend= t '.upload_document'
-p= t '.additional_information_rtf'
-= f.input :additional_information_rtf, label: false do
-  - if resource.has_additional_information_rtf?
-    = f.input :remove_additional_information_rtf, as: :boolean,
-      inline_label: t('.remove_additional_information_rtf',
+= f.input :claim_details_rtf do
+  - if resource.has_claim_details_rtf?
+    = f.input :remove_claim_details_rtf, as: :boolean,
+      inline_label: t('.remove_claim_details_rtf',
         file: resource.attachment_filename),
         label: false
-  = f.input_field :additional_information_rtf, as: :file
-= f.hidden_field :additional_information_rtf_cache
+  = f.input_field :claim_details_rtf, as: :file
+= f.hidden_field :claim_details_rtf_cache
 
 fieldset
   legend= t '.similar_claims'

--- a/app/views/claims/_claim_details.html.slim
+++ b/app/views/claims/_claim_details.html.slim
@@ -1,22 +1,27 @@
 h2.legend= t '.claim_details'
 
 p= t('.claim_details_html', path: guide_path)
-p= t('.upload_details')
+
+details open=resource.has_claim_details_rtf?
+  summary role='button' aria={ \
+    expanded: "#{resource.has_claim_details_rtf?}",
+    controls: 'details-content-0'}
+    span.summary= t('.claim_details_upload')
+
+  .panel-indent#details-content-0
+    = f.input :claim_details_rtf do
+      = f.input_field :claim_details_rtf, as: :file do
+    - if resource.has_claim_details_rtf?
+      = f.input :remove_claim_details_rtf, as: :boolean,
+          inline_label: t('.remove_claim_details_rtf',
+            file: resource.attachment_filename),
+            label: false
+    = f.hidden_field :claim_details_rtf_cache
 
 = f.input :claim_details, label: false,
   hint: t('.claim_details_hint_html', path: guide_path),
   as: :text,
-  input_html: { rows: 30 }
-
-legend= t '.upload_document'
-= f.input :claim_details_rtf do
-  - if resource.has_claim_details_rtf?
-    = f.input :remove_claim_details_rtf, as: :boolean,
-      inline_label: t('.remove_claim_details_rtf',
-        file: resource.attachment_filename),
-        label: false
-  = f.input_field :claim_details_rtf, as: :file
-= f.hidden_field :claim_details_rtf_cache
+  input_html: { rows: 15 }
 
 fieldset
   legend= t '.similar_claims'

--- a/app/views/claims/_claim_details.html.slim
+++ b/app/views/claims/_claim_details.html.slim
@@ -1,11 +1,23 @@
 h2.legend= t '.claim_details'
 
 p= t('.claim_details_html', path: guide_path)
+p= t('.upload_details')
 
 = f.input :claim_details, label: false,
   hint: t('.claim_details_hint_html', path: guide_path),
   as: :text,
   input_html: { rows: 30 }
+
+legend= t '.upload_document'
+p= t '.additional_information_rtf'
+= f.input :additional_information_rtf, label: false do
+  - if resource.has_additional_information_rtf?
+    = f.input :remove_additional_information_rtf, as: :boolean,
+      inline_label: t('.remove_additional_information_rtf',
+        file: resource.attachment_filename),
+        label: false
+  = f.input_field :additional_information_rtf, as: :file
+= f.hidden_field :additional_information_rtf_cache
 
 fieldset
   legend= t '.similar_claims'

--- a/config/locales/claim_review.en.yml
+++ b/config/locales/claim_review.en.yml
@@ -110,6 +110,7 @@ en:
         claim_details: Claim details
         other_known_claimant_names: Other known claimants
         miscellaneous_information: Other information
+        attached_document: Attached documents
 
       claim_outcome:
         desired_outcomes: What outcome?
@@ -117,7 +118,6 @@ en:
 
       additional_information:
         miscellaneous_information: Important details
-        attached_document: Attached documents
 
       your_fee:
         seeking_remission: Fee remission

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,7 +242,7 @@ en:
       claim_details:
         other_known_claimants: Do you know of any other claimants (not already listed) making similar claims against the same employer?
         other_known_claimant_names: You can add the names of other people here.
-        claim_details_rtf: If you need more space, you can upload a separate document here.
+        claim_details_rtf: The document needs to be in Rich Text Format(RTF)
       claim_outcome:
         desired_outcomes: What do you want if your claim is successful?
         other_outcome: What compensation or other outcome do you want?
@@ -315,8 +315,7 @@ en:
           A judge may combine similar claims to manage and hear them together. This may save you and the tribunal time and money.
         other_known_claimant_names: Limit is 350 characters.
         claim_details_rtf: |
-          The document needs to be in Rich Text Format (RTF). You can usually save a file
-          as RTF by selecting File> Save As> Export To> Format: Rich Text Format
+          You can usually save a file as RTF by selecting File> Save As> Export To> Format: Rich Text Format
 
       claim_outcome:
         desired_outcomes: You can select more than one
@@ -579,12 +578,13 @@ en:
 
     claim_details:
       header: Claim details
-      claim_details: About your claim
+      claim_details: Describe your claim
+      claim_details_upload: Or upload it as a separate document
       claim_details_html: |
-        Include the background, dates and people involved. <a href="%{path}#writing_your_claim_statement">More about writing your claim statement</a>.
-      upload_details: If you need more space, you can upload a separate document below.
+        Write your claim statement below.
+        Include the background, dates and people involved.
+        <a href="%{path}#writing_your_claim_statement">More about writing your claim statement</a>.
       claim_details_hint_html: Limit is 5000 characters (approx 900 words).
-      upload_document: Upload document
       remove_claim_details_rtf: |
         Remove previously uploaded document: %{file}
       similar_claims: Similar claims

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,9 +229,6 @@ en:
         is_whistleblowing: Are you reporting suspected wrongdoing at work?
         send_claim_to_whistleblowing_entity: Do you want us to send a copy of your claim to the relevant person or body that deals with whistleblowing?
 
-      additional_information:
-        additional_information_rtf: Do you want to attach a document?
-
       confirmation_email:
         email_addresses: Select or enter the recipients you’d like to send a copy to
 
@@ -245,6 +242,7 @@ en:
       claim_details:
         other_known_claimants: Do you know of any other claimants (not already listed) making similar claims against the same employer?
         other_known_claimant_names: You can add the names of other people here.
+        claim_details_rtf: If you need more space, you can upload a separate document here.
       claim_outcome:
         desired_outcomes: What do you want if your claim is successful?
         other_outcome: What compensation or other outcome do you want?
@@ -316,6 +314,9 @@ en:
         other_known_claimants: |
           A judge may combine similar claims to manage and hear them together. This may save you and the tribunal time and money.
         other_known_claimant_names: Limit is 350 characters.
+        claim_details_rtf: |
+          The document needs to be in Rich Text Format (RTF). You can usually save a file
+          as RTF by selecting File> Save As> Export To> Format: Rich Text Format
 
       claim_outcome:
         desired_outcomes: You can select more than one
@@ -496,7 +497,7 @@ en:
       steps_header: Spreadsheet for group claim
       error_line: "An error has been found on line %{line_number} of the uploaded file."
       malformatted_csv: The CSV doesn’t appear to be formatted correctly.
-      remove_additional_claimants_csv: :"claims.claim_details.remove_additional_information_rtf"
+      remove_additional_claimants_csv: :"claims.claim_details.remove_claim_details_rtf"
       number_claimants_info: For 6 or more claimants, enter their details below.
       has_additional_claimants_html: For up to 5 other claimants you can enter their details <a href="%{path}">manually</a>.
       step_one_header: Step 1
@@ -580,14 +581,11 @@ en:
       header: Claim details
       claim_details: About your claim
       claim_details_html: |
-        Include the background, dates and people involved. If you prefer, you can write more on a separate document and upload it later in the claim. <a href="%{path}#writing_your_claim_statement">More about writing your claim statement</a>.
+        Include the background, dates and people involved. <a href="%{path}#writing_your_claim_statement">More about writing your claim statement</a>.
       upload_details: If you need more space, you can upload a separate document below.
       claim_details_hint_html: Limit is 5000 characters (approx 900 words).
-      upload_document: Upload Document
-      additional_information_rtf: |
-        The document needs to be in Rich Text Format (RTF). You can usually save a file
-        as RTF by selecting File> Save As> Export To> Format: Rich Text Format
-      remove_additional_information_rtf: |
+      upload_document: Upload document
+      remove_claim_details_rtf: |
         Remove previously uploaded document: %{file}
       similar_claims: Similar claims
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,11 +323,6 @@ en:
            If you’re claiming financial compensation, you can say how much you want and how you worked out the sum. You can change these details later, or leave this section blank if you don’t know.
       additional_information:
         miscellaneous_information: Enter more detail about your claim. Limit is 5000 characters (approx 900 words).
-        additional_information_rtf: |
-          You can upload a separate document if you need more space to describe your claim. Please do not send any
-          evidence documents at this stage. The document needs to be a Rich Text Format (RTF) file. You can usually save
-          a file as an RTF by selecting File > Save As / Export To > Format: Rich Text Format
-      your_fee:
 
       user_session:
         new:
@@ -501,7 +496,7 @@ en:
       steps_header: Spreadsheet for group claim
       error_line: "An error has been found on line %{line_number} of the uploaded file."
       malformatted_csv: The CSV doesn’t appear to be formatted correctly.
-      remove_additional_claimants_csv: :"claims.additional_information.remove_additional_information_rtf"
+      remove_additional_claimants_csv: :"claims.claim_details.remove_additional_information_rtf"
       number_claimants_info: For 6 or more claimants, enter their details below.
       has_additional_claimants_html: For up to 5 other claimants you can enter their details <a href="%{path}">manually</a>.
       step_one_header: Step 1
@@ -584,8 +579,16 @@ en:
     claim_details:
       header: Claim details
       claim_details: About your claim
-      claim_details_html: Include the background, dates and people involved. If you prefer, you can write more on a separate document and upload it later in the claim. <a href="%{path}#writing_your_claim_statement">More about writing your claim statement</a>.
+      claim_details_html: |
+        Include the background, dates and people involved. If you prefer, you can write more on a separate document and upload it later in the claim. <a href="%{path}#writing_your_claim_statement">More about writing your claim statement</a>.
+      upload_details: If you need more space, you can upload a separate document below.
       claim_details_hint_html: Limit is 5000 characters (approx 900 words).
+      upload_document: Upload Document
+      additional_information_rtf: |
+        The document needs to be in Rich Text Format (RTF). You can usually save a file
+        as RTF by selecting File> Save As> Export To> Format: Rich Text Format
+      remove_additional_information_rtf: |
+        Remove previously uploaded document: %{file}
       similar_claims: Similar claims
 
     claim_outcome:
@@ -600,9 +603,8 @@ en:
         Include anything that will help the tribunal come to a decision about whether your case can be heard.
         What you write may be seen by the respondent. If you are making a claim against more than 3 additional respondents,
         enter their details below.
-      remove_additional_information_rtf: |
-        Remove previously uploaded document: %{file}
-      upload_limit: :'claims.additional_claimants_upload.upload_limit'
+      has_miscellaneous_information_hint: Include anything that will help the tribunal come to a decision about whether your case can be heard. What you write may be seen by the respondent.
+      additional_respondents_callout: If you are making a claim against more than 3 additional respondents, enter their details below.
 
     your_fee:
       header: Fee

--- a/db/migrate/20150212171232_rename_additional_information_rtf_to_claim_details_rtf_on_claim.rb
+++ b/db/migrate/20150212171232_rename_additional_information_rtf_to_claim_details_rtf_on_claim.rb
@@ -1,0 +1,5 @@
+class RenameAdditionalInformationRtfToClaimDetailsRtfOnClaim < ActiveRecord::Migration
+  def change
+    rename_column :claims, :additional_information_rtf, :claim_details_rtf
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,41 +32,41 @@ ActiveRecord::Schema.define(version: 20150217155539) do
   add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
 
   create_table "addresses", force: :cascade do |t|
-    t.string   "building",         limit: 255
-    t.string   "street",           limit: 255
-    t.string   "locality",         limit: 255
-    t.string   "county",           limit: 255
-    t.string   "post_code",        limit: 255
+    t.string   "building"
+    t.string   "street"
+    t.string   "locality"
+    t.string   "county"
+    t.string   "post_code"
     t.integer  "addressable_id"
-    t.string   "addressable_type", limit: 255
+    t.string   "addressable_type"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "telephone_number", limit: 255
-    t.string   "country",          limit: 255
-    t.boolean  "primary",                      default: true
+    t.string   "telephone_number"
+    t.string   "country"
+    t.boolean  "primary",          default: true
   end
 
   create_table "claimants", force: :cascade do |t|
-    t.string   "first_name",         limit: 255
-    t.string   "last_name",          limit: 255
+    t.string   "first_name"
+    t.string   "last_name"
     t.date     "date_of_birth"
-    t.string   "mobile_number",      limit: 255
-    t.string   "fax_number",         limit: 255
-    t.string   "email_address",      limit: 255
+    t.string   "mobile_number"
+    t.string   "fax_number"
+    t.string   "email_address"
     t.text     "special_needs"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "claim_id"
-    t.string   "gender",             limit: 255
-    t.string   "contact_preference", limit: 255
-    t.string   "title",              limit: 255
-    t.boolean  "primary_claimant",               default: false
+    t.string   "gender"
+    t.string   "contact_preference"
+    t.string   "title"
+    t.boolean  "primary_claimant",   default: false
   end
 
   create_table "claims", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "password_digest",                       limit: 255
+    t.string   "password_digest"
     t.boolean  "is_unfair_dismissal"
     t.integer  "discrimination_claims"
     t.integer  "pay_claims"
@@ -83,13 +83,13 @@ ActiveRecord::Schema.define(version: 20150217155539) do
     t.datetime "submitted_at"
     t.string   "additional_information_rtf"
     t.string   "email_address"
-    t.integer  "remission_claimant_count",                          default: 0
     t.string   "additional_claimants_csv"
-    t.integer  "additional_claimants_csv_record_count",             default: 0
-    t.string   "application_reference",                                          null: false
-    t.integer  "payment_attempts",                                  default: 0
+    t.integer  "remission_claimant_count",              default: 0
+    t.integer  "additional_claimants_csv_record_count", default: 0
+    t.string   "application_reference",                              null: false
+    t.integer  "payment_attempts",                      default: 0
     t.string   "pdf"
-    t.string   "confirmation_email_recipients",                     default: [],              array: true
+    t.string   "confirmation_email_recipients",         default: [],              array: true
   end
 
   add_index "claims", ["application_reference"], name: "index_claims_on_application_reference", unique: true, using: :btree
@@ -107,12 +107,12 @@ ActiveRecord::Schema.define(version: 20150217155539) do
     t.integer  "net_pay"
     t.integer  "new_job_gross_pay"
     t.float    "average_hours_worked_per_week"
-    t.string   "current_situation",                    limit: 255
-    t.string   "gross_pay_period_type",                limit: 255
-    t.string   "job_title",                            limit: 255
-    t.string   "net_pay_period_type",                  limit: 255
-    t.string   "new_job_gross_pay_frequency",          limit: 255
-    t.string   "notice_pay_period_type",               limit: 255
+    t.string   "current_situation"
+    t.string   "gross_pay_period_type"
+    t.string   "job_title"
+    t.string   "net_pay_period_type"
+    t.string   "new_job_gross_pay_frequency"
+    t.string   "notice_pay_period_type"
     t.text     "benefit_details"
     t.integer  "claim_id"
     t.datetime "created_at"
@@ -148,27 +148,27 @@ ActiveRecord::Schema.define(version: 20150217155539) do
   end
 
   create_table "representatives", force: :cascade do |t|
-    t.string   "type",               limit: 255
-    t.string   "organisation_name",  limit: 255
-    t.string   "name",               limit: 255
-    t.string   "mobile_number",      limit: 255
-    t.string   "email_address",      limit: 255
-    t.string   "dx_number",          limit: 255
+    t.string   "type"
+    t.string   "organisation_name"
+    t.string   "name"
+    t.string   "mobile_number"
+    t.string   "email_address"
+    t.string   "dx_number"
     t.integer  "claim_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "contact_preference", limit: 255
+    t.string   "contact_preference"
   end
 
   create_table "respondents", force: :cascade do |t|
-    t.string   "name",                                       limit: 255
-    t.string   "acas_early_conciliation_certificate_number", limit: 255
-    t.string   "no_acas_number_reason",                      limit: 255
+    t.string   "name"
+    t.string   "acas_early_conciliation_certificate_number"
+    t.string   "no_acas_number_reason"
     t.integer  "claim_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "worked_at_same_address",                                 default: true
-    t.boolean  "primary_respondent",                                     default: false
+    t.boolean  "worked_at_same_address",                     default: true
+    t.boolean  "primary_respondent",                         default: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 20150217155539) do
     t.string   "fee_group_reference"
     t.string   "state"
     t.datetime "submitted_at"
-    t.string   "additional_information_rtf"
+    t.string   "claim_details_rtf"
     t.string   "email_address"
     t.string   "additional_claimants_csv"
     t.integer  "remission_claimant_count",              default: 0

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
 
     is_unfair_dismissal true
 
-    additional_information_rtf do
+    claim_details_rtf do
       Rack::Test::UploadedFile.new 'spec/support/files/file.rtf'
     end
 
@@ -98,7 +98,7 @@ FactoryGirl.define do
     end
 
     trait :no_attachments do
-      additional_information_rtf nil
+      claim_details_rtf nil
       additional_claimants_csv nil
     end
 
@@ -107,7 +107,7 @@ FactoryGirl.define do
         Rack::Test::UploadedFile.new 'spec/support/files/file-l_o_l.biz._v1_.csv'
       end
 
-      additional_information_rtf do
+      claim_details_rtf do
         Rack::Test::UploadedFile.new 'spec/support/files/file-l_o_l.biz._v1_.rtf'
       end
     end

--- a/spec/features/attaching_a_document_spec.rb
+++ b/spec/features/attaching_a_document_spec.rb
@@ -19,9 +19,9 @@ feature 'Attaching a document' do
 
     context 'Uploading a valid RTF file' do
       before :each do
-        visit '/apply/additional-information'
-        attach_file "additional_information_additional_information_rtf", rtf_file_path
-        click_button 'Save and continue'
+        visit '/apply/claim-details'
+        attach_file "claim_details_additional_information_rtf", rtf_file_path
+        fill_in_claim_details
       end
 
       scenario 'Attaching the file' do
@@ -29,16 +29,16 @@ feature 'Attaching a document' do
       end
 
       scenario 'Deleting the file' do
-        visit '/apply/additional-information'
-        check "additional_information_remove_additional_information_rtf"
+        visit '/apply/claim-details'
+        check "claim_details_remove_additional_information_rtf"
         click_button 'Save and continue'
 
         expect(claim.reload.additional_information_rtf.present?).to be false
       end
 
       scenario 'Replacing the file' do
-        visit '/apply/additional-information'
-        attach_file "additional_information_additional_information_rtf", alternative_rtf_file_path
+        visit '/apply/claim-details'
+        attach_file "claim_details_additional_information_rtf", alternative_rtf_file_path
         click_button 'Save and continue'
 
         expect(claim.reload.additional_information_rtf_file.read).to eq File.read(alternative_rtf_file_path)
@@ -46,8 +46,8 @@ feature 'Attaching a document' do
     end
 
     scenario 'Uploading a non text file' do
-      visit '/apply/additional-information'
-      attach_file "additional_information_additional_information_rtf", invalid_file_path
+      visit '/apply/claim-details'
+      attach_file "claim_details_additional_information_rtf", invalid_file_path
       click_button 'Save and continue'
 
       expect(page).to have_text('is not an RTF')

--- a/spec/features/attaching_a_document_spec.rb
+++ b/spec/features/attaching_a_document_spec.rb
@@ -13,45 +13,45 @@ feature 'Attaching a document' do
     fill_in_return_form claim.reference, 'lollolol'
   end
 
-  describe 'For additional information' do
+  describe 'For claim details RTF upload' do
     let(:rtf_file_path) { file_path + './file.rtf' }
     let(:alternative_rtf_file_path) { file_path + './alt_file.rtf' }
 
     context 'Uploading a valid RTF file' do
       before :each do
         visit '/apply/claim-details'
-        attach_file "claim_details_additional_information_rtf", rtf_file_path
+        attach_file "claim_details_claim_details_rtf", rtf_file_path
         fill_in_claim_details
       end
 
       scenario 'Attaching the file' do
-        expect(claim.reload.additional_information_rtf_file.read).to eq File.read(rtf_file_path)
+        expect(claim.reload.claim_details_rtf_file.read).to eq File.read(rtf_file_path)
       end
 
       scenario 'Deleting the file' do
         visit '/apply/claim-details'
-        check "claim_details_remove_additional_information_rtf"
+        check "claim_details_remove_claim_details_rtf"
         click_button 'Save and continue'
 
-        expect(claim.reload.additional_information_rtf.present?).to be false
+        expect(claim.reload.claim_details_rtf.present?).to be false
       end
 
       scenario 'Replacing the file' do
         visit '/apply/claim-details'
-        attach_file "claim_details_additional_information_rtf", alternative_rtf_file_path
+        attach_file "claim_details_claim_details_rtf", alternative_rtf_file_path
         click_button 'Save and continue'
 
-        expect(claim.reload.additional_information_rtf_file.read).to eq File.read(alternative_rtf_file_path)
+        expect(claim.reload.claim_details_rtf_file.read).to eq File.read(alternative_rtf_file_path)
       end
     end
 
     scenario 'Uploading a non text file' do
       visit '/apply/claim-details'
-      attach_file "claim_details_additional_information_rtf", invalid_file_path
+      attach_file "claim_details_claim_details_rtf", invalid_file_path
       click_button 'Save and continue'
 
       expect(page).to have_text('is not an RTF')
-      expect(claim.additional_information_rtf).not_to be_present
+      expect(claim.claim_details_rtf).not_to be_present
     end
   end
 

--- a/spec/forms/additional_information_form_spec.rb
+++ b/spec/forms/additional_information_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe AdditionalInformationForm, :type => :form do
+RSpec.describe AdditionalInformationForm, type: :form do
   subject { described_class.new(resource) }
 
   let(:resource) { Claim.new }
@@ -10,39 +10,6 @@ RSpec.describe AdditionalInformationForm, :type => :form do
       context 'when has_miscellaneous_information is true' do
         before { subject.has_miscellaneous_information = 'true' }
         it     { is_expected.to ensure_length_of(:miscellaneous_information).is_at_most(5000) }
-      end
-    end
-
-    describe 'on #additional_information_rtf' do
-      let(:path) { Pathname.new(Rails.root) + 'spec/support/files' }
-
-      before do
-        subject.additional_information_rtf = file
-        subject.valid?
-      end
-
-      context 'when its value is a rtf document' do
-        let(:file) { File.open(path + 'file.rtf') }
-
-        it 'does nothing' do
-          expect(subject.errors[:additional_information_rtf]).to be_empty
-        end
-      end
-
-      context 'when its value is a plain text document' do
-        let(:file) { File.open(path + 'lel.txt') }
-
-        it 'adds an error message to the attribute' do
-          expect(subject.errors[:additional_information_rtf]).to include(I18n.t 'errors.messages.rtf')
-        end
-      end
-
-      context 'when its value is not a rtf document' do
-        let(:file) { File.open(path + 'phil.jpg') }
-
-        it 'adds an error message to the attribute' do
-          expect(subject.errors[:additional_information_rtf]).to include(I18n.t 'errors.messages.rtf')
-        end
       end
     end
 

--- a/spec/forms/claim_details_form_spec.rb
+++ b/spec/forms/claim_details_form_spec.rb
@@ -14,6 +14,31 @@ RSpec.describe ClaimDetailsForm, :type => :form do
     end
   end
 
+  describe 'on #additional_information_rtf' do
+    let(:path) { Rails.root + 'spec/support/files' }
+
+    before do
+      subject.additional_information_rtf = file
+      subject.valid?
+    end
+
+    context 'when its value is a plain text file' do
+      let(:file) { File.open(path + 'file.rtf') }
+
+      it 'does nothing' do
+        expect(subject.errors[:additional_information_rtf]).to be_empty
+      end
+    end
+
+    context 'when its value is not a plain text file' do
+      let(:file) { File.open(path + 'phil.jpg') }
+
+      it 'adds an error message to the attribute' do
+        expect(subject.errors[:additional_information_rtf]).to include(I18n.t 'errors.messages.rtf')
+      end
+    end
+  end
+
   describe '#other_known_claimants' do
     context 'when #other_known_claimant_names is blank' do
       it 'is false' do

--- a/spec/forms/claim_details_form_spec.rb
+++ b/spec/forms/claim_details_form_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe ClaimDetailsForm, :type => :form do
     end
   end
 
-  describe 'on #additional_information_rtf' do
+  describe 'on #claim_details_rtf' do
     let(:path) { Rails.root + 'spec/support/files' }
 
     before do
-      subject.additional_information_rtf = file
+      subject.claim_details_rtf = file
       subject.valid?
     end
 
@@ -26,7 +26,7 @@ RSpec.describe ClaimDetailsForm, :type => :form do
       let(:file) { File.open(path + 'file.rtf') }
 
       it 'does nothing' do
-        expect(subject.errors[:additional_information_rtf]).to be_empty
+        expect(subject.errors[:claim_details_rtf]).to be_empty
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe ClaimDetailsForm, :type => :form do
       let(:file) { File.open(path + 'phil.jpg') }
 
       it 'adds an error message to the attribute' do
-        expect(subject.errors[:additional_information_rtf]).to include(I18n.t 'errors.messages.rtf')
+        expect(subject.errors[:claim_details_rtf]).to include(I18n.t 'errors.messages.rtf')
       end
     end
   end

--- a/spec/forms/claim_details_form_spec.rb
+++ b/spec/forms/claim_details_form_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe ClaimDetailsForm, :type => :form do
   describe 'validations' do
     context 'presence' do
       it { is_expected.to validate_presence_of(:claim_details) }
+
+      context 'claim details attached as an RTF' do
+        before { subject.claim_details_rtf = Tempfile.new('suchclaimdetails') }
+        it { is_expected.to_not validate_presence_of(:claim_details) }
+      end
     end
 
     context 'character lengths' do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Claim, type: :claim do
     specify { expect(subject.attachments.size).to eq 3 }
 
     it "only returns attachments that exist" do
-      expect { subject.remove_additional_information_rtf! }.
+      expect { subject.remove_claim_details_rtf! }.
         to change { subject.attachments.size }.
         from(3).to(2)
     end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -310,6 +310,16 @@ RSpec.describe Claim, type: :claim do
     end
   end
 
+  describe '#remove_claim_details_rtf!' do
+    before { subject.claim_details_rtf = Tempfile.new('suchclaimdetails') }
+
+    it 'removes the rtf file' do
+      expect { subject.remove_claim_details_rtf! }.
+        to change { subject.claim_details_rtf.present? }.
+        from(true).to(false)
+    end
+  end
+
   describe "#generate_pdf!" do
     subject { create :claim }
 

--- a/spec/presenters/additional_information_presenter_spec.rb
+++ b/spec/presenters/additional_information_presenter_spec.rb
@@ -8,5 +8,4 @@ RSpec.describe AdditionalInformationPresenter, type: :presenter do
   end
 
   its(:miscellaneous_information) { is_expected.to eq("<p>hey\n<br />hey</p>") }
-  its(:attached_document) { is_expected.to eq('file.rtf') }
 end

--- a/spec/presenters/claim_details_presenter_spec.rb
+++ b/spec/presenters/claim_details_presenter_spec.rb
@@ -1,16 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe ClaimDetailsPresenter, type: :presenter do
-  subject { described_class.new claim_detail }
+  subject { described_class.new claim }
 
-  let(:claim_detail) do
-    double 'claim_detail',
-      is_unfair_dismissal: true, discrimination_claims: [:sex_including_equal_pay, :race, :sexual_orientation],
-      pay_claims: [:redundancy, :other], other_claim_details: "yo\r\nyo",
+  let(:claim) do
+    create :claim,
       claim_details: "wut\r\nwut",
-      other_known_claimant_names: "Johnny Wishbone\r\nSamuel Pepys",
-      is_whistleblowing: true, send_claim_to_whistleblowing_entity: false,
-      miscellaneous_information: "hey\r\nhey"
+      other_known_claimant_names: "Johnny Wishbone\r\nSamuel Pepys"
   end
 
   its(:claim_details) { is_expected.to eq("<p>wut\n<br />wut</p>") }
@@ -18,4 +14,6 @@ RSpec.describe ClaimDetailsPresenter, type: :presenter do
   its(:other_known_claimant_names) do
     is_expected.to eq("<p>Johnny Wishbone\n<br />Samuel Pepys</p>")
   end
+
+  its(:attached_document) { is_expected.to eq('file.rtf') }
 end

--- a/spec/presenters/jadu_xml/file_presenter_spec.rb
+++ b/spec/presenters/jadu_xml/file_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe JaduXml::FilePresenter, type: :presenter do
   let(:claim) { create :claim }
 
-  subject { described_class.new claim.additional_information_rtf }
+  subject { described_class.new claim.claim_details_rtf }
 
   describe "decorated methods" do
     describe "#filename" do

--- a/spec/services/jadu/claim_spec.rb
+++ b/spec/services/jadu/claim_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Jadu::Claim, type: :service do
 
   let(:attachments) do
     { "et1_barrington_wrigglesworth.pdf" => claim.pdf_file.read,
-      "file.rtf" => claim.additional_information_rtf_file.read,
+      "file.rtf" => claim.claim_details_rtf_file.read,
       "file.csv" => claim.additional_claimants_csv_file.read }
   end
 
@@ -52,7 +52,7 @@ RSpec.describe Jadu::Claim, type: :service do
 
       let(:attachments) do
         { "et1_barrington_wrigglesworth.pdf" => claim.pdf_file.read,
-          "file_l_o_l_biz__v1_.rtf" => claim.additional_information_rtf_file.read,
+          "file_l_o_l_biz__v1_.rtf" => claim.claim_details_rtf_file.read,
           "file_l_o_l_biz__v1_.csv" => claim.additional_claimants_csv_file.read }
       end
 


### PR DESCRIPTION
This renames the column on the claims table, because of this it will also mean we have to re-sync the files in S3. I just didn't want to have the uploader called additional_information_rtf & still have the additional_information_form.

Updated with new designs(Monday 9th March)