### PR TITLE
Wrap most of the package script in `set -e` to stop on error

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 CONTAINERS=(assets rails)
 
 DEFAULT_DOCKERREPO="docker.local:5000"
@@ -128,6 +130,8 @@ cat <<EOT >public/assets/ping.json
 {"version_number":"$APPVERSION","build_date":"$DATE","commit_id":"$GIT_COMMIT","build_tag":"$BUILD_TAG"}
 EOT
 
+# After here we capture the retcode when we need it, so turn off automatic fail on error
+set +e
 
 JENKINS_RETCODE=0
 
@@ -148,6 +152,7 @@ done
 if [ -z "$DOCKER_NOPUSH" ]; then
 	for i in  ${CONTAINERS[@]}; do
 		docker_push $i $APPVERSION
+		RETCODE=$?
   		if [ "$RETCODE" -ne 0 ]; then
      			JENKINS_RETCODE=$RETCODE
      			output "Failed $i push with code $RETCODE"


### PR DESCRIPTION
The docker push stuff at the end we want to carry on to remove images so
the jenkins server doesn't bloat.