### PR TITLE
Remove security/phishing from email footers

### DIFF
--- a/app/views/base_mailer/access_details_email.en.text.erb
+++ b/app/views/base_mailer/access_details_email.en.text.erb
@@ -12,6 +12,3 @@ You’ll receive a confirmation email once you’ve submitted your claim.
 
 Contact us: http://www.justice.gov.uk/contacts/hmcts/tribunals/employment
 
-If you’re not sure whether an email is from the Ministry of Justice then:
-  - do not reply or click any links
-  - forward it to security@digital.justice.gov.uk

--- a/app/views/base_mailer/confirmation_email.text.erb
+++ b/app/views/base_mailer/confirmation_email.text.erb
@@ -34,7 +34,3 @@ Claim number: <%= @presenter.reference %>
 <%= t('.diversity_text') -%> https://www.employmenttribunals.service.gov.uk/forms/form/175/en/diversity_monitoring_questionnaire
 
 <%= t('.footer.contact_us') %>: http://www.justice.gov.uk/contacts/hmcts/tribunals/employment
-
-<%= t('.footer.if_you_are_unsure') -%>
-  - <%= t('.footer.do_not_reply') -%>
-  - <%= t('.footer.forward_it') -%>

--- a/app/views/base_mailer/shared/_footer.html.slim
+++ b/app/views/base_mailer/shared/_footer.html.slim
@@ -6,13 +6,5 @@ table style="width:100%; padding:20px 0px 20px 60px; background-color:#dee0e2; h
           a style="color:#6F777B;" href="http://www.justice.gov.uk/contacts/hmcts/tribunals/employment" target="_blank"
             = t('base_mailer.footer.contact_us')
 
-        p style="font-family:arial; font-size:16px; color:#6F777B;"
-          = t('base_mailer.footer.if_you_are_unsure')
-
-        ul
-          li style="font-family:arial; font-size:16px; color:#6F777B;"
-            = t('base_mailer.footer.do_not_reply')
-          li style="font-family:arial; font-size:16px; color:#6F777B;"
-            = t('base_mailer.footer.forward_it')
       td
         img src="https://s3-eu-west-1.amazonaws.com/mojet-emails/govuk_crest_email.png"

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -2,12 +2,6 @@ en:
   base_mailer:
     footer:
       contact_us: Contact us
-      if_you_are_unsure: |
-        If you’re not sure whether an email is from the Ministry of Justice then:
-      do_not_reply: |
-        do not reply to it or click any links
-      forward_it: |
-        forward it to security@digital.justice.gov.uk
 
     access_details_email:
       subject: 'Employment tribunal: complete your claim'


### PR DESCRIPTION
We decided that having this doesn't help as any scammers could just remove this or change the email address, and it seems that users are hitting reply-to-all and getting emails to this list.

I have no idea if this will pas its tests as I don't know how/what to set the missing env vars too (`key not found: "EPDQ_PSPID" (KeyError)` for starters)