### PR TITLE
Shorter strings for pdf fields.

### DIFF
--- a/app/forms/additional_information_form.rb
+++ b/app/forms/additional_information_form.rb
@@ -5,7 +5,7 @@ class AdditionalInformationForm < Form
   before_validation :reset_miscellaneous_information!,
     unless: :has_miscellaneous_information?
 
-  validates :miscellaneous_information, length: { maximum: 5000 }
+  validates :miscellaneous_information, length: { maximum: 2500 }
 
   def has_miscellaneous_information
     self.has_miscellaneous_information = miscellaneous_information.present?

--- a/app/forms/claim_details_form.rb
+++ b/app/forms/claim_details_form.rb
@@ -12,7 +12,7 @@ class ClaimDetailsForm < Form
   delegate :claim_details_rtf_cache, :claim_details_rtf_cache=,
     :remove_claim_details_rtf!, to: :target
 
-  validates :claim_details, length: { maximum: 5000 },
+  validates :claim_details, length: { maximum: 2500 },
     presence: true, unless: -> { claim_details_rtf.present? }
   validates :other_known_claimant_names, length: { maximum: 350 }
   validates :claim_details_rtf, content_type: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -322,7 +322,7 @@ en:
         other_outcome: |
            If you’re claiming financial compensation, you can say how much you want and how you worked out the sum. You can change these details later, or leave this section blank if you don’t know.
       additional_information:
-        miscellaneous_information: Enter more detail about your claim. Limit is 5000 characters (approx 900 words).
+        miscellaneous_information: Enter more detail about your claim. Limit is 2500 characters (approx 450 words).
 
       user_session:
         new:
@@ -584,7 +584,7 @@ en:
         Write your claim statement below.
         Include the background, dates and people involved.
         <a href="%{path}#writing_your_claim_statement">More about writing your claim statement</a>.
-      claim_details_hint_html: Limit is 5000 characters (approx 900 words).
+      claim_details_hint_html: Limit is 2500 characters (approx 450 words).
       remove_claim_details_rtf: |
         Remove previously uploaded document: %{file}
       similar_claims: Similar claims

--- a/spec/forms/additional_information_form_spec.rb
+++ b/spec/forms/additional_information_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AdditionalInformationForm, type: :form do
     describe 'on #miscellaneous information' do
       context 'when has_miscellaneous_information is true' do
         before { subject.has_miscellaneous_information = 'true' }
-        it     { is_expected.to ensure_length_of(:miscellaneous_information).is_at_most(5000) }
+        it     { is_expected.to ensure_length_of(:miscellaneous_information).is_at_most(2500) }
       end
     end
 

--- a/spec/forms/claim_details_form_spec.rb
+++ b/spec/forms/claim_details_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ClaimDetailsForm, :type => :form do
     end
 
     context 'character lengths' do
-      it { is_expected.to ensure_length_of(:claim_details).is_at_most(5000) }
+      it { is_expected.to ensure_length_of(:claim_details).is_at_most(2500) }
       it { is_expected.to ensure_length_of(:other_known_claimant_names).is_at_most(350) }
     end
   end


### PR DESCRIPTION
This reduces the maximum number of characters for claim details and additional information. This should prevent truncation of these fields in the fixed space of the PDF boxes.