### PR TITLE
Email validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ gem 'susy'
 gem 'compass'
 gem 'virtus'
 gem 'zendesk_api'
+gem 'email_validator'
 # This gem ensures rails 4 also builds a non-digest version of the assets
 # so that static pages can refer to them.
 gem "non-stupid-digest-assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,8 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    email_validator (1.5.0)
+      activemodel
     equalizer (0.0.9)
     erubis (2.7.0)
     eventmachine (1.0.4)
@@ -539,6 +541,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   compass
   dotenv-rails (= 0.11.1)
+  email_validator
   epdq!
   factory_girl_rails
   fog

--- a/app/forms/application_number_form.rb
+++ b/app/forms/application_number_form.rb
@@ -5,6 +5,7 @@ class ApplicationNumberForm < Form
   attribute :email_address, String
 
   validates :password, presence: true
+  validates :email_address, email: true, allow_blank: true
 
   def target
     resource

--- a/app/forms/representative_form.rb
+++ b/app/forms/representative_form.rb
@@ -18,6 +18,7 @@ class RepresentativeForm < Form
   validates :organisation_name, :name, length: { maximum: 100 }
   validates :dx_number, length: { maximum: 40 }
   validates :mobile_number, length: { maximum: PHONE_NUMBER_LENGTH }
+  validates :email_address, email: true, allow_blank: true
 
   def valid?
     if has_representative?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -644,6 +644,8 @@ en:
           attributes:
             password:
               blank: Please create a memorable word so you can return to your claim
+            email_address:
+              invalid: You have entered an invalid email address
         additional_claimants_form/additional_claimant:
           attributes:
             title:
@@ -752,6 +754,7 @@ en:
               invalid: Please enter a valid postcode or if your representative lives abroad, please enter SW55 9QT
             email_address:
               blank: Please enter your representative’s email address
+              invalid: You have entered an invalid email address
         respondent:
           attributes:
             name:

--- a/spec/forms/application_number_form_spec.rb
+++ b/spec/forms/application_number_form_spec.rb
@@ -7,11 +7,18 @@ RSpec.describe ApplicationNumberForm, type: :form do
     context 'presence' do
       it { is_expected.to validate_presence_of(:password) }
     end
+    context 'no_email' do
+      it { is_expected.not_to validate_presence_of(:email_address) }
+    end
+
+    include_examples "Email validation",
+      error_message: 'You have entered an invalid email address'
   end
 
   describe '#save' do
     context "if successful it runs callbacks" do
       before { subject.password = "supersecure" }
+      before { subject.email_address = "" }
 
       it "attempts to deliver access details via email" do
         expect(AccessDetailsMailer).to receive(:deliver_later)

--- a/spec/forms/representative_form_spec.rb
+++ b/spec/forms/representative_form_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe RepresentativeForm, :type => :form do
       include_examples "Postcode validation",
         attribute_prefix: 'address',
         error_message: 'Please enter a valid postcode or if your representative lives abroad, please enter SW55 9QT'
+      include_examples "Email validation",
+        error_message: 'You have entered an invalid email address'
     end
 
     context 'when has_representative? == false' do

--- a/spec/support/shared_examples/email_validation.rb
+++ b/spec/support/shared_examples/email_validation.rb
@@ -1,0 +1,39 @@
+RSpec.shared_examples 'Email validation' do |options|
+  describe 'validating a email' do
+    let(:errors)        { subject.errors[:"email_address"] }
+    let(:error_message) { options[:error_message] }
+
+    context 'when no email' do
+      before do
+        subject.send :"email_address=", ''
+        subject.valid?
+      end
+
+      it 'does not add any errors' do
+        expect(errors).not_to include error_message
+      end
+    end
+
+    context 'when it is not a valid email' do
+      before do
+        subject.send :"email_address=", 'lol@ biz.info'
+        subject.valid?
+      end
+
+      it 'adds an error to the email attribute' do
+        expect(errors).to include error_message
+      end
+    end
+
+    context 'when it is a valid email' do
+      before do
+        subject.send :"email_address=", 'lol@biz.info'
+        subject.valid?
+      end
+
+      it 'does not add any errors' do
+        expect(errors).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds email validation to the user's and representitives' email addresses. This is mostly to ensure that no spaces are entered in the email address as it causes ActionMailer to blow up.