### PR TITLE
Render empty respondents work address in XML

### DIFF
--- a/app/presenters/jadu_xml/address_properties.rb
+++ b/app/presenters/jadu_xml/address_properties.rb
@@ -3,11 +3,11 @@ module JaduXml
     extend ActiveSupport::Concern
 
     included do
-      property :building,   as: 'Line'
-      property :street,     as: 'Street'
-      property :locality,   as: 'Town'
-      property :county,     as: 'County'
-      property :post_code,  as: 'Postcode'
+      property :building,   as: 'Line',     render_nil: true
+      property :street,     as: 'Street',   render_nil: true
+      property :locality,   as: 'Town',     render_nil: true
+      property :county,     as: 'County',   render_nil: true
+      property :post_code,  as: 'Postcode', render_nil: true
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -162,6 +162,10 @@ FactoryGirl.define do
       no_acas_number_reason nil
       acas_early_conciliation_certificate_number "SOMEACASNUMBER"
     end
+
+    trait :without_work_address do
+      addresses { [create(:address, primary: true)] }
+    end
   end
 
   factory :payment do

--- a/spec/features/claim_xml_generation_spec.rb
+++ b/spec/features/claim_xml_generation_spec.rb
@@ -176,12 +176,22 @@ feature 'Generating XML for a claim', type: :feature do
 
       context 'renders nil elements' do
         respondent = FactoryGirl.create :respondent,
-          work_address_telephone_number: nil, address_telephone_number: nil
+          :without_work_address,
+          work_address_telephone_number: nil,
+          address_telephone_number: nil
 
         include_context 'assign claim', primary_respondent: respondent
 
+        it 'has an AltAddress with empty nodes' do
+          expect(doc.xpath('//Respondent/AltAddress/Line')).not_to be_empty
+          expect(doc.xpath('//Respondent/AltAddress/Street')).not_to be_empty
+          expect(doc.xpath('//Respondent/AltAddress/Town')).not_to be_empty
+          expect(doc.xpath('//Respondent/AltAddress/County')).not_to be_empty
+          expect(doc.xpath('//Respondent/AltAddress/Postcode')).not_to be_empty
+        end
+
         it 'has an empty AltPhoneNumber' do
-          expect(xpath('//Respondent/AltPhoneNumber'))
+          expect(doc.xpath('//Respondent/AltPhoneNumber')).not_to be_empty
         end
       end
 
@@ -191,14 +201,14 @@ feature 'Generating XML for a claim', type: :feature do
 
           it 'contains a Number' do
             expect(xpath('//Respondent/Acas/Number')).to eq 'SOMEACASNUMBER'
-            expect(xpath('//Respondent/Acas/ExemptionCode')).to be_empty
+            expect(doc.xpath('//Respondent/Acas/ExemptionCode')).to be_empty
           end
         end
 
         context 'with no acas number' do
           it 'contains an ExemptionCode' do
             expect(xpath('//Respondent/Acas/ExemptionCode')).to eq 'employer_contacted_acas'
-            expect(xpath('//Respondent/Acas/Number')).to be_empty
+            expect(doc.xpath('//Respondent/Acas/Number')).to be_empty
           end
         end
       end


### PR DESCRIPTION
Ensure that respondents with empty work addresses validates correctly against V0.24 of the Jadu Schema when represented as XML.