### PR TITLE
Improved Year Validation For Date Fields

### DIFF
--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,13 +1,27 @@
 class DateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    # Hash failed to be coerced into Date, e.g. invalid date
-    # Empty String as D.O.B is optional field on CSV - this makes me v. sad!
-    if value.is_a?(Hash) || is_non_empty_string?(value)
+    if coercion_failed?(value) || non_empty_string?(value) || illegal_year?(value)
       record.errors.add(attribute)
     end
   end
 
-  private def is_non_empty_string?(value)
-    value.is_a?(String) && !value.blank?
+  private
+
+  def coercion_failed?(value)
+    # Hash failed to be coerced into Date, e.g. invalid date
+    value.is_a?(Hash)
+  end
+
+  def non_empty_string?(value)
+    # Strings can be passed in the date field when uploading a CSV
+    # An empty string should not be flagged as an error
+
+    # TODO: CSV Date validation should be handled separately
+    value.is_a?(String) && value.present?
+  end
+
+  def illegal_year?(value)
+    # Needs to verify that four digits are given for a year
+    value.is_a?(Date) && value.year < 1_000
   end
 end

--- a/spec/support/shared_examples/date.rb
+++ b/spec/support/shared_examples/date.rb
@@ -58,6 +58,17 @@ RSpec.shared_examples 'it parses dates' do |*dates|
             expect(subject.errors[date]).to include I18n.t(model_translation_path)
           end
         end
+
+        context 'when a year with less than 4 digits is provided' do
+          before do
+            subject.send "#{date}=", 'day' => '1', 'month' => '1', 'year' => '72'
+            subject.valid?
+          end
+
+          it "adds a validation error to #{date}" do
+            expect(subject.errors[date]).to include I18n.t(model_translation_path)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Adds a check to ensure the year is greater than 1000 so as to guarantee the user provided 4 digits. This stops users creating dates in the format dd/mm/yy - which is now necessary as Jadu require a date of birth to be passed in the xml.