### PR TITLE
Adds a customer validator to the claim type form - WIP

### DIFF
--- a/app/forms/claim_type_form.rb
+++ b/app/forms/claim_type_form.rb
@@ -10,6 +10,8 @@ class ClaimTypeForm < Form
 
   before_validation :reset_claim_details!, unless: :is_other_type_of_claim?
 
+  validates_with ClaimTypePresenceValidator
+
   def is_other_type_of_claim
     self.is_other_type_of_claim = other_claim_details.present?
   end

--- a/app/validators/claim_type_presence_validator.rb
+++ b/app/validators/claim_type_presence_validator.rb
@@ -1,0 +1,18 @@
+class ClaimTypePresenceValidator < ActiveModel::Validator
+  def validate(form)
+    unless single_choice_selected?(form) || multiple_choice_selected?(form)
+      form.errors.add(:base, :invalid)
+    end
+  end
+
+  private
+
+  def single_choice_selected?(form)
+    %i<is_unfair_dismissal is_other_type_of_claim is_whistleblowing>.
+      find { |predicate| form.send predicate }
+  end
+
+  def multiple_choice_selected?(form)
+    [*form.pay_claims, *form.discrimination_claims].reject(&:blank?).any?
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -688,6 +688,10 @@ en:
           attributes:
             additional_claimants_csv:
               blank: You must provide a CSV file in order to continue
+        claim_type:
+          attributes:
+            base:
+              invalid: You must select at least one claim type in order to continue
         claim_details:
           attributes:
             claim_details:

--- a/spec/forms/claim_type_form_spec.rb
+++ b/spec/forms/claim_type_form_spec.rb
@@ -26,6 +26,40 @@ RSpec.describe ClaimTypeForm, :type => :form do
     end
   end
 
+  describe 'validations' do
+    subject { described_class.new Claim.new }
+
+    context 'no claim type is provided' do
+      it 'adds a validation error' do
+        subject.valid?
+        expect(subject.errors[:base]).
+          to include I18n.t 'activemodel.errors.models.claim_type.attributes.base.invalid'
+      end
+    end
+
+    %i<is_unfair_dismissal is_whistleblowing>.each do |boolean_claim_type|
+      context "#{boolean_claim_type} boolean option is selected" do
+        before { subject.send "#{boolean_claim_type}=", 'true' }
+        its(:valid?) { is_expected.to be_truthy }
+      end
+    end
+
+    context 'other claim details have been provided' do
+      before do
+        subject.is_other_type_of_claim = 'true'
+        subject.other_claim_details = 'such nonsense'
+      end
+      its(:valid?) { is_expected.to be_truthy }
+    end
+
+    { discrimination_claims: :disability, pay_claims: :notice }.each do |claim_type, issue|
+      context "at least one option selected for the category: #{claim_type}" do
+        before { subject.send "#{claim_type}=", issue }
+        its(:valid?) { is_expected.to be_truthy }
+      end
+    end
+  end
+
   describe 'callbacks' do
     it 'clears other_claim_details when selecting no' do
       subject.other_claim_details = 'other details'


### PR DESCRIPTION
Adds validation to the claim type form that checks the presence of at least one claim type being selected. 

Failure for the user to do that results in an error message being displayed in the global errors box at the top of the page.

- [x] adds a custom validator that checks the presence of at least one claim type
- [ ] restructure the layout of the page so it makes a little more sense to the user
- [ ] handling error for other claim details field

##### update: awaiting feedback from Dan T on whether this validation is even required.