### PR TITLE
Submit Claim Button Text Fix For Group Claims

### DIFF
--- a/app/helpers/claim_reviews_helper.rb
+++ b/app/helpers/claim_reviews_helper.rb
@@ -32,7 +32,7 @@ module ClaimReviewsHelper
   end
 
   def submit_button_text
-    if claim.remission_applicable?
+    if claim.application_fee_after_remission.zero?
       t '.submit_with_remission'
     else
       t '.submit_go_to_payment'

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -159,7 +159,7 @@ class Claim < ActiveRecord::Base
 
   alias_method :setup_state_machine, :state_machine
 
-  delegate :fee_to_pay?, :application_fee, to: :fee_calculation
+  delegate :fee_to_pay?, :application_fee, :application_fee_after_remission, to: :fee_calculation
 
   private
 

--- a/spec/features/create_claim_applications_spec.rb
+++ b/spec/features/create_claim_applications_spec.rb
@@ -258,20 +258,47 @@ feature 'Claim applications', type: :feature do
       expect(page).to have_text "Processing a copy of your claim"
     end
 
-    scenario 'Viewing the confirmation page when seeking remission' do
-      complete_a_claim seeking_remissions: true
-      click_button 'Submit claim'
+    context 'Viewing the confirmation page' do
+      scenario 'with a single claimant when seeking remission' do
+        complete_a_claim seeking_remissions: true
+        click_button 'Submit claim', exact: true
 
-      expect(page).to have_text 'Apply for fee remission'
-      expect(page).not_to have_text 'You now need to pay the issue fee'
-    end
+        expect(page).to have_text 'Apply for fee remission'
+        expect(page).not_to have_text 'You now need to pay the issue fee'
+      end
 
-    scenario 'Viewing the confirmation page when not seeking remission' do
-      complete_a_claim seeking_remissions: false
-      click_button 'Submit claim'
+      scenario 'with a single claimant when not seeking remission' do
+        complete_a_claim seeking_remissions: false
+        click_button 'Submit claim and proceed to payment'
 
-      expect(page).not_to have_text 'Apply for fee remission'
-      expect(page).to have_text "When you've paid the issue fee, the local tribunal office will review your claim"
+        expect(page).not_to have_text 'Apply for fee remission'
+        expect(page).to have_text "When you've paid the issue fee, the local tribunal office will review your claim"
+      end
+
+      scenario 'as part of a group claim with no remission' do
+        complete_a_claim additional_claimants: true, seeking_remissions: 0
+        click_button 'Submit claim and proceed to payment'
+
+        expect(page).not_to have_text 'Apply for fee remission'
+        expect(page).to have_text "When you've paid the issue fee, the local tribunal office will review your claim"
+      end
+
+      scenario 'as part of a group claim with partial remission' do
+        complete_a_claim additional_claimants: true, seeking_remissions: 1
+        click_button 'Submit claim and proceed to payment'
+
+        expect(page).not_to have_text 'Apply for fee remission'
+        expect(page).to have_text "When you've paid the issue fee, the local tribunal office will review your claim"
+
+      end
+
+      scenario 'as part of a group with full remission' do
+        complete_a_claim additional_claimants: true, seeking_remissions: 2
+        click_button 'Submit claim', exact: true
+
+        expect(page).to have_text 'Apply for fee remission'
+        expect(page).not_to have_text 'You now need to pay the issue fee'
+      end
     end
   end
 end

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -103,8 +103,25 @@ module FormMethods
     click_button 'Save and continue' unless options[:submit_form] == false
   end
 
-  def fill_in_additional_claimant_details
-    choose "No"
+  def fill_in_additional_claimant_details(options={})
+    if options[:additional_claimants]
+      choose "Yes"
+
+      select 'Mr', from: 'Title'
+      fill_in 'First name', with: 'Edmund'
+      fill_in 'Last name',  with: 'Wrigglesworth'
+      fill_in 'Day',   with: '22'
+      fill_in 'Month', with: '01'
+      fill_in 'Year',  with: '1985'
+      fill_in 'Building number or name', with: '2'
+      fill_in 'Street',                  with: 'High street'
+      fill_in 'Town/city',               with: 'Anytown'
+      fill_in 'County',                  with: 'Anyfordshire'
+      fill_in 'Postcode',                with: 'AT1 4PQ'
+    else
+      choose "No"
+    end
+
     click_button 'Save and continue'
   end
 
@@ -239,7 +256,12 @@ module FormMethods
   end
 
   def fill_in_your_fee(options={})
-    choose "your_fee_applying_for_remission_#{options.fetch(:seeking_remissions) { false }}"
+    if options[:additional_claimants]
+      fill_in 'How many in your group want to apply for fee remission?',
+        with: options[:seeking_remissions]
+    else
+      choose "your_fee_applying_for_remission_#{options.fetch(:seeking_remissions) { false }}"
+    end
 
     click_button 'Save and continue'
   end
@@ -257,7 +279,7 @@ module FormMethods
     start_claim
     fill_in_password
     fill_in_personal_details(options)
-    fill_in_additional_claimant_details
+    fill_in_additional_claimant_details(options)
     fill_in_representative_details
     fill_in_respondent_details
     fill_in_additional_respondent_details


### PR DESCRIPTION
Prior to this PR - a group with partial remission showed the button text that a full remission claim would have. 

The cause of this was due to the method for presenting the button text checked only remission had been applied - it now checks the remission count instead.