### PR TITLE
Explicitly state that no attachments are present on the confirmation page/email

### DIFF
--- a/app/presenters/confirmation_presenter.rb
+++ b/app/presenters/confirmation_presenter.rb
@@ -14,7 +14,11 @@ class ConfirmationPresenter < Presenter
   end
 
   def attachments
-    attachment_filenames.map { |f| sanitize(f) }.join(file_separator).html_safe
+    if attachment_filenames.empty?
+      I18n.t 'claim_confirmations.show.no_attachments'
+    else
+      attachment_filenames.map { |f| sanitize(f) }.join(file_separator).html_safe
+    end
   end
 
   def payment_amount
@@ -33,7 +37,6 @@ class ConfirmationPresenter < Presenter
 
   def items
     %i<submission_information attachments payment_amount>.tap do |arr|
-      arr.delete :attachments if attachment_filenames.empty?
       arr.delete :payment_amount unless fee_to_pay?
     end
   end
@@ -43,8 +46,8 @@ class ConfirmationPresenter < Presenter
   end
 
   def attachment_filenames
-    [claim_details_rtf, additional_claimants_csv].map do |attachment|
-      CarrierwaveFilename.for attachment
-    end.compact
+    @attachment_filenames ||= \
+      [claim_details_rtf, additional_claimants_csv].
+        map { |attachment| CarrierwaveFilename.for attachment }.compact
   end
 end

--- a/config/locales/claim_confirmation.en.yml
+++ b/config/locales/claim_confirmation.en.yml
@@ -30,6 +30,8 @@ en:
         link_html: |
           <a href="%{href}" target="%{target}">Save a copy</a> for your records
 
+      no_attachments: None
+
       submission_details:
         header: Submission details
         submission_information: Claim submitted

--- a/spec/presenters/confirmation_presenter_spec.rb
+++ b/spec/presenters/confirmation_presenter_spec.rb
@@ -74,10 +74,11 @@ RSpec.describe ConfirmationPresenter, type: :presenter do
     context 'when no attachments were uploaded' do
       let(:claim) { create :claim, :no_attachments }
 
-      it 'yields no attachment information' do
+      it 'yields text to state no attachments are present' do
         expect { |b| subject.each_item &b }.
-        to yield_successive_args [:submission_information, "Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU"],
-        [:payment_amount, "£250.00"]
+          to yield_successive_args [:submission_information, "Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU"],
+          [:attachments, "None"],
+          [:payment_amount, "£250.00"]
       end
     end
   end


### PR DESCRIPTION
Adds the text 'None' if no files are present, else the file names are presented instead.

![no_attachment_screenshot](https://cloud.githubusercontent.com/assets/1006365/7394448/85f05f92-ee8b-11e4-9db7-247a15574bb3.png)

Fixes #678 