### PR TITLE
Make workers configurable

### DIFF
--- a/config/initializers/amqp.rb
+++ b/config/initializers/amqp.rb
@@ -4,12 +4,13 @@ if Rails.env.production?
   Sneakers.configure \
     amqp:    "amqp://#{ENV.fetch('RABBIT_USER')}:#{ENV.fetch('RABBIT_PASSWORD')}@#{ENV.fetch('RABBIT_HOST')}:#{ENV.fetch('RABBIT_PORT')}",
     vhost:   ENV.fetch('RABBIT_VHOST'),
+    workers: Integer(ENV.fetch('SNEAKERS_WORKERS')),
     durable: true,
     handler: Sneakers::Handlers::Maxretry,
     log:     'log/sneakers.log',
-    timeout_job_after: ENV.fetch('SNEAKERS_TIMEOUT_S').to_i,
-    retry_timeout: ENV.fetch('SNEAKERS_RETRY_TTL_MS').to_i, #milliseconds
-    max_retries: ENV.fetch('SNEAKERS_MAX_RETRIES').to_i,
+    timeout_job_after: Integer(ENV.fetch('SNEAKERS_TIMEOUT_S')),
+    retry_timeout: Integer(ENV.fetch('SNEAKERS_RETRY_TTL_MS')), #milliseconds
+    max_retries: Integer(ENV.fetch('SNEAKERS_MAX_RETRIES')),
     hooks: {
         before_fork: -> {
           Sneakers.logger.info('Worker: Disconnect from the database')
@@ -17,7 +18,7 @@ if Rails.env.production?
         },
         after_fork: -> {
           config = Rails.application.config.database_configuration[Rails.env]
-          config['pool'] = ENV.fetch('SNEAKERS_DB_POOL', 1).to_i #Limit the number of TCP connections per worker
+          config['pool'] = Integer(ENV.fetch('SNEAKERS_DB_POOL', 1)) #Limit the number of TCP connections per worker
           ActiveRecord::Base.establish_connection(config)
           Sneakers.logger.info('Worker: Reconnect to the database')
         }

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,1 @@
+worker_processes Integer(ENV.fetch("WEB_CONCURRENCY"))

--- a/docker/rails/unicorn.service
+++ b/docker/rails/unicorn.service
@@ -13,5 +13,5 @@ seed)
     ;;
 esac
 echo "Starting unicorn"           >>/rails/log/unicorn.log
-exec bundle exec unicorn -p 80    >>/rails/log/unicorn.log 2>&1
+exec bundle exec unicorn -p 80 -c ./config/unicorn.rb    >>/rails/log/unicorn.log 2>&1
 


### PR DESCRIPTION
This makes it possible to define the number of worker processess for
sneakers and unicorn through environment variables.

Also move to parsing integers with the Integer class rather than .to_i
which is safer because it throws an exception if given a string as
input.