### PR TITLE
Strips whitespace from the primary claimants first & last name

### DIFF
--- a/app/forms/claimant_form.rb
+++ b/app/forms/claimant_form.rb
@@ -56,6 +56,14 @@ class ClaimantForm < Form
     resource.primary_claimant || resource.build_primary_claimant
   end
 
+  def first_name=(name)
+    super name.try :strip
+  end
+
+  def last_name=(name)
+    super name.try :strip
+  end
+
   private
 
   def international_address?

--- a/spec/forms/claimant_form_spec.rb
+++ b/spec/forms/claimant_form_spec.rb
@@ -82,6 +82,15 @@ RSpec.describe ClaimantForm, :type => :form do
     end
   end
 
+  describe 'overridden attribute setters' do
+    %i<first_name last_name>.each do |attribute|
+      it "strips whitespace from the #{attribute}" do
+        subject.send "#{attribute}=", ' Such '
+        expect(subject.send(attribute)).to eq 'Such'
+      end
+    end
+  end
+
   it_behaves_like 'it parses dates', :date_of_birth
   it_behaves_like "a Form", title: 'mr', gender: 'male', contact_preference: 'email',
     first_name: 'Barrington', last_name: 'Wrigglesworth',


### PR DESCRIPTION
PDF filenames can no longer have spaces in them as first and last names values are now 'stripped' before being persisted.

Fixes #707 