### PR TITLE
Ensure a user cannot re-enter the form once session has expired

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,5 @@
 class UserSessionsController < ApplicationController
+  skip_after_action :set_session_expiry, only: :expired
   redispatch_request unless: :present?, except: %i<new create>
 
   def destroy
@@ -24,6 +25,10 @@ class UserSessionsController < ApplicationController
 
   def touch
     render nothing: true
+  end
+
+  def expired
+    reset_session
   end
 
   private

--- a/spec/features/save_and_return_spec.rb
+++ b/spec/features/save_and_return_spec.rb
@@ -83,6 +83,18 @@ feature 'Save and Return' do
     expect(page).to have_field('Last name', with: 'Wrigglesworth')
   end
 
+  scenario 'returning to an existing application after session expiration' do
+    start_claim
+    fill_in_password 'green'
+    fill_in_personal_details
+
+    travel_to TimeHelper.session_expiry_time do
+      fill_in_return_form Claim.last.reference, 'green'
+      expect(page).to have_text(claim_heading_for(:claimant))
+      expect(page).to have_field('Last name', with: 'Wrigglesworth')
+    end
+  end
+
   context 'memorable word not set' do
     scenario 'returning to an existing application' do
       start_claim

--- a/spec/features/session_expiry_spec.rb
+++ b/spec/features/session_expiry_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 feature 'Session Expiry', type: :feature do
   include FormMethods
 
-  let(:session_expiry_time) { 1.hours.from_now + 1.second }
-
   context 'within the context of creating a claim' do
     context 'outside of the allocated time frame for a user session' do
 
@@ -12,22 +10,31 @@ feature 'Session Expiry', type: :feature do
 
       ClaimPagesManager.page_names.each do |page_name|
         scenario "a user is directed to a session expiry page for page: #{page_name}" do
-          travel_to session_expiry_time do
+          travel_to TimeHelper.session_expiry_time do
             visit("#{page_name}")
-            expect(page).to have_text "Session expired"
+            expect(page).to have_text 'Session expired'
+            expect(current_path).to eq expired_user_session_path
           end
         end
       end
 
+      scenario 'a user is unable to re-enter the form from the expiry page' do
+        travel_to TimeHelper.session_expiry_time do
+          visit claim_claimant_path
+          expect(current_path).to eq expired_user_session_path
+          visit claim_claimant_path
+          expect(current_path).to eq apply_path
+        end
+      end
     end
   end
 
-  context "on the start page of the application" do
-    scenario "a users session doesn't expire" do
-      visit "/"
-      travel_to session_expiry_time do
-        click_button "Start a claim"
-        expect(page).not_to have_text "Session expired"
+  context 'on the start page of the application' do
+    scenario 'a users session does not expire' do
+      visit apply_path
+      travel_to TimeHelper.session_expiry_time do
+        click_button 'Start a claim'
+        expect(current_path).to eq claim_application_number_path
       end
     end
   end

--- a/spec/support/time_helper.rb
+++ b/spec/support/time_helper.rb
@@ -1,0 +1,7 @@
+module TimeHelper
+  def session_expiry_time
+    61.minutes.from_now
+  end
+
+  extend self
+end


### PR DESCRIPTION
Hitting the user sessions controller would reset the session expires_in value thus keeping the session alive. 

This fix ensures the action that sets the sessions expires_in time is not executed when a user hits the expiry page.