### PR TITLE
Adds a presenter for confirmation email addresses on review page

### DIFF
--- a/app/helpers/claim_reviews_helper.rb
+++ b/app/helpers/claim_reviews_helper.rb
@@ -13,10 +13,7 @@ module ClaimReviewsHelper
   end
 
   def email_addresses
-    claimants = claim.claimants.pluck(:email_address)
-    representatives = [claim.representative.try(:email_address)]
-
-    (claimants + representatives).reject(&:blank?)
+    ConfirmationEmailAddressesPresenter.email_addresses_for claim
   end
 
   def claim_presenter

--- a/app/presenters/confirmation_email_addresses_presenter.rb
+++ b/app/presenters/confirmation_email_addresses_presenter.rb
@@ -1,0 +1,26 @@
+class ConfirmationEmailAddressesPresenter < Struct.new(:claim)
+  delegate :primary_claimant, :representative, :secondary_claimants, to: :claim
+
+  def self.email_addresses_for(claim)
+    new(claim).filter_email_addresses
+  end
+
+  def filter_email_addresses
+    [primary_claimant_email, representative_email].
+      reject { |email| email.first.blank? }
+  end
+
+  private
+
+  def primary_claimant_email
+    [primary_claimant.email_address, checked: tick_primary_claimant?]
+  end
+
+  def representative_email
+    [representative.try(:email_address), checked: true]
+  end
+
+  def tick_primary_claimant?
+    secondary_claimants.none? || representative.try(:email_address).blank?
+  end
+end

--- a/app/views/claim_reviews/_email_addresses.html.slim
+++ b/app/views/claim_reviews/_email_addresses.html.slim
@@ -7,7 +7,7 @@
         collection: email_addresses,
         as: :check_boxes,
         label: false,
-        input_html: { checked: true }
+        value_method: :first
 
     fieldset style="margin-top:60px;"
       legend role="header" aria-level="2" = t('.submit_warning_header')

--- a/spec/presenters/confirmation_email_addresses_presenter_spec.rb
+++ b/spec/presenters/confirmation_email_addresses_presenter_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe ConfirmationEmailAddressesPresenter, type: :presenter do
+  subject { described_class.email_addresses_for claim }
+
+  let(:claimant_with_email)           { create :claimant, primary_claimant: true, email_address: 'such@lol.biz' }
+  let(:representative_with_email)     { create :representative, email_address: 'edgar@lol.biz' }
+  let(:claimant_without_email)        { create :claimant, primary_claimant: true, email_address: nil }
+  let(:representative_without_email)  { create :representative, email_address: nil }
+
+  describe '.for' do
+    context 'only the primary claimant has an email' do
+      let(:claim) do
+        create :claim,
+          primary_claimant: claimant_with_email, representative: representative_without_email
+      end
+
+      it 'returns one email with the check property set' do
+        expect(subject).to eq [['such@lol.biz', { checked: true }]]
+      end
+    end
+
+    context 'only the representative has an email' do
+      let(:claim) do
+        create :claim,
+          primary_claimant: claimant_without_email, representative: representative_with_email
+      end
+
+      it 'returns one email with the check property set' do
+        expect(subject).to eq [['edgar@lol.biz', { checked: true }]]
+      end
+    end
+
+    context 'primary claimant & representative emails present' do
+      let(:claim) do
+        create :claim,
+          primary_claimant: claimant_with_email, representative: representative_with_email
+      end
+
+      it 'returns two emails with checked properties set' do
+        expect(subject).to eq [['such@lol.biz', { checked: true }], ['edgar@lol.biz', { checked: true }]]
+      end
+    end
+
+    context 'multiple claimants & representative email present' do
+      let(:claim) do
+        create :claim, :with_secondary_claimants,
+          primary_claimant: claimant_with_email, representative: representative_with_email
+      end
+
+      it 'returns two emails with only the representative checked property set' do
+        expect(subject).to eq [['such@lol.biz', { checked: false }], ['edgar@lol.biz', { checked: true }]]
+      end
+    end
+
+    context 'no emails have been provided' do
+      let(:claim) do
+        create :claim,
+          primary_claimant: claimant_without_email, representative: representative_without_email
+      end
+
+      specify { expect(subject).to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
Presenter that returns a list of emails & determines the checked properties of the emails based on which emails are present in the claim.

Fixes #737 