### PR TITLE
Log events when the status of a successful barclaycard callback is uncertain

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < ActiveRecord::Base
   REJECTED_BY_JADU            = 'rejected_by_jadu'.freeze
   CONFIRMATION_EMAIL_SENT     = 'confirmation_email_sent'.freeze
   PAYMENT_RECEIVED            = 'payment_received'.freeze
+  PAYMENT_UNCERTAIN           = 'payment_uncertain'.freeze
   PAYMENT_DECLINED            = 'payment_declined'.freeze
   PDF_GENERATED               = 'pdf_generated'.freeze
 

--- a/app/services/payment_gateway/response.rb
+++ b/app/services/payment_gateway/response.rb
@@ -1,7 +1,7 @@
-# Namespace for encapsulating Payment gateway related code
 module PaymentGateway
-  # Encapsulates ePDQ response related code
   class Response < Struct.new(:request)
+    SUCCESS_CODES = %w<5 51 9 91>.freeze
+
     def valid?
       EPDQ::Response.new(request.query_string).valid_signature?
     rescue RuntimeError
@@ -11,7 +11,7 @@ module PaymentGateway
     end
 
     def success?
-      %w<5 51 9 91>.include? params['STATUS']
+      SUCCESS_CODES.include? status
     end
 
     def amount
@@ -20,6 +20,10 @@ module PaymentGateway
 
     def reference
       params['PAYID']
+    end
+
+    def status
+      params['STATUS']
     end
 
     private def params

--- a/config/locales/barclaycard_gateway.en.yml
+++ b/config/locales/barclaycard_gateway.en.yml
@@ -1,0 +1,12 @@
+en:
+  barclaycard_gateway:
+    # Information taken from the Barclaycard e-Commerce advanced guide
+    # Technical Integration Guide for e-Commerce v.5.4.0
+    responses:
+      '52': |
+        Status 52: Authorisation Not Known - A technical problem arose during the
+        authorisation/payment process, giving an unpredicatable result.
+      '92': |
+        Status 92: Payment Uncertain - The customer should not retry the authorisation
+        process since the authorisation/payment might already have been accepted.
+      generic: "Status Code: %{status}"

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -17,41 +17,107 @@ RSpec.describe PaymentsController do
       allow(claim).to receive_messages(create_payment: true, enqueue!: true)
     end
 
-    context 'for a successful payment' do
-      it 'logs an event' do
-        expect(claim).to receive(:create_event).with 'payment_received'
+    describe 'when a callback hits the success endpoint' do
+      context 'with a successful response' do
+        it 'logs an event' do
+          expect(claim).to receive(:create_event).with 'payment_received'
 
-        get :success,
-          'orderID' => '511234567800',
-          'amount' => '250',
-          'PM' => 'CreditCard',
-          'ACCEPTANCE' => 'test123',
-          'STATUS' => '9',
-          'CARDNO' => 'XXXXXXXXXXXX111',
-          'TRXDATE' => '09/15/14',
-          'PAYID' => '34707458',
-          'NCERROR' => '0',
-          'BRAND' => 'VISA',
-          'SHASIGN' => 'A8410E130DA5C6AB210CF8E64CAFA64EC8AC8EFF0D958AC0D2CB3AF3EE467E75'
+          get :success,
+            'orderID' => '511234567800',
+            'amount' => '250',
+            'PM' => 'CreditCard',
+            'ACCEPTANCE' => 'test123',
+            'STATUS' => '9',
+            'CARDNO' => 'XXXXXXXXXXXX111',
+            'TRXDATE' => '09/15/14',
+            'PAYID' => '34707458',
+            'NCERROR' => '0',
+            'BRAND' => 'VISA',
+            'SHASIGN' => 'A8410E130DA5C6AB210CF8E64CAFA64EC8AC8EFF0D958AC0D2CB3AF3EE467E75'
+        end
+      end
+
+      context 'with an uncertain payment status' do
+        context 'with a 52: authorisation unknown status' do
+          it 'logs an event with a message' do
+            expect(claim).to receive(:create_event).
+              with 'payment_uncertain', message: /Status 52: Authorisation Not Known/
+
+            get :success,
+              'orderID' => '511234567800',
+              'amount' => '250',
+              'PM' => 'CreditCard',
+              'ACCEPTANCE' => 'test123',
+              'STATUS' => '52',
+              'CARDNO' => 'XXXXXXXXXXXX111',
+              'TRXDATE' => '09/15/14',
+              'PAYID' => '34707458',
+              'NCERROR' => '0',
+              'BRAND' => 'VISA',
+              'SHASIGN' => '05D8A34BA87286420FB2FCBEE78DB1223FB241505CBA8DAED09D3D384235CAD2'
+          end
+        end
+
+        context 'with a 92: payment uncertain status' do
+          it 'logs an event with a message' do
+            expect(claim).to receive(:create_event).
+              with 'payment_uncertain', message: /Status 92: Payment Uncertain/
+
+            get :success,
+              'orderID' => '511234567800',
+              'amount' => '250',
+              'PM' => 'CreditCard',
+              'ACCEPTANCE' => 'test123',
+              'STATUS' => '92',
+              'CARDNO' => 'XXXXXXXXXXXX111',
+              'TRXDATE' => '09/15/14',
+              'PAYID' => '34707458',
+              'NCERROR' => '0',
+              'BRAND' => 'VISA',
+              'SHASIGN' => '5C4888CBF89FD8005B22E106D8F3F1CD3453982D7475E78F724BB0951C27C27F'
+          end
+        end
+
+        context 'with an unrecognized response status' do
+          it 'logs an event with a message containing the status code' do
+            expect(claim).to receive(:create_event).
+              with 'payment_uncertain', message: /Status Code: 999/
+
+            get :success,
+              'orderID' => '511234567800',
+              'amount' => '250',
+              'PM' => 'CreditCard',
+              'ACCEPTANCE' => 'test123',
+              'STATUS' => '999',
+              'CARDNO' => 'XXXXXXXXXXXX111',
+              'TRXDATE' => '09/15/14',
+              'PAYID' => '34707458',
+              'NCERROR' => '0',
+              'BRAND' => 'VISA',
+              'SHASIGN' => '2DD49AE6327E81A8CF8ADF95165BB440E28A6F4B21F9CF4EA83CC7CBBFB76D18'
+          end
+        end
       end
     end
 
-    context 'for a failed payment' do
-      it 'logs an event' do
-        expect(claim).to receive(:create_event).with 'payment_declined'
+    describe 'when a callback hits the decline endpoint' do
+      context 'for a failed payment' do
+        it 'logs an event' do
+          expect(claim).to receive(:create_event).with 'payment_declined'
 
-        get :decline,
-          'orderID' => '511234567800',
-          'amount' => '250',
-          'PM' => 'CreditCard',
-          'ACCEPTANCE' => 'test123',
-          'STATUS' => '9',
-          'CARDNO' => 'XXXXXXXXXXXX111',
-          'TRXDATE' => '09/15/14',
-          'PAYID' => '34707458',
-          'NCERROR' => '0',
-          'BRAND' => 'VISA',
-          'SHASIGN' => 'A8410E130DA5C6AB210CF8E64CAFA64EC8AC8EFF0D958AC0D2CB3AF3EE467E75'
+          get :decline,
+            'orderID' => '511234567800',
+            'amount' => '250',
+            'PM' => 'CreditCard',
+            'ACCEPTANCE' => 'test123',
+            'STATUS' => '9',
+            'CARDNO' => 'XXXXXXXXXXXX111',
+            'TRXDATE' => '09/15/14',
+            'PAYID' => '34707458',
+            'NCERROR' => '0',
+            'BRAND' => 'VISA',
+            'SHASIGN' => 'A8410E130DA5C6AB210CF8E64CAFA64EC8AC8EFF0D958AC0D2CB3AF3EE467E75'
+        end
       end
     end
   end

--- a/spec/services/payment_gateway/response_spec.rb
+++ b/spec/services/payment_gateway/response_spec.rb
@@ -73,4 +73,10 @@ RSpec.describe PaymentGateway::Response, type: :service do
       expect(subject.reference).to eq '34707458'
     end
   end
+
+  describe '#status' do
+    it 'returns the status code from the gateway response' do
+      expect(subject.status).to eq '9'
+    end
+  end
 end


### PR DESCRIPTION
Assigns an event to a claim for instances when barclaycard cannot guarantee at the time a user submits payment whether the payment has actually been authorised.