### PR TITLE
Set sneakers to log to STDOUT

### DIFF
--- a/config/initializers/amqp.rb
+++ b/config/initializers/amqp.rb
@@ -7,7 +7,7 @@ if Rails.env.production?
     workers: Integer(ENV.fetch('SNEAKERS_WORKERS')),
     durable: true,
     handler: Sneakers::Handlers::Maxretry,
-    log:     'log/sneakers.log',
+    log:     STDOUT,
     timeout_job_after: Integer(ENV.fetch('SNEAKERS_TIMEOUT_S')),
     retry_timeout: Integer(ENV.fetch('SNEAKERS_RETRY_TTL_MS')), #milliseconds
     max_retries: Integer(ENV.fetch('SNEAKERS_MAX_RETRIES')),

--- a/docker/rails/Dockerfile
+++ b/docker/rails/Dockerfile
@@ -25,6 +25,8 @@ ADD docker/rails/logstash-conf.sh /etc/logstash-conf.sh
 # install service files for runit
 ADD docker/rails/unicorn.service /etc/service/unicorn/run
 ADD docker/rails/sneakers.service /etc/service/sneakers/run
+RUN mkdir -p /rails/log/sneakers
+ADD docker/rails/sneakers.logger /etc/service/sneakers/log/run
 
 # The way this base image handles envvars is pretty strange
 COPY docker/app_env_vars /etc/container_environment/

--- a/docker/rails/logstash-conf.sh
+++ b/docker/rails/logstash-conf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-for file in unicorn.log production.log logstash_production.json sneakers.log;
+for file in unicorn.log production.log logstash_production.json;
   do touch /rails/log/$file
 done
 
@@ -33,7 +33,7 @@ cat <<EOT
       add_field => [ "format",    "json" ]
     }
     file {
-      path  => "/rails/log/sneakers.log"
+      path  => "/rails/log/sneakers/current"
       type  => "rails"
       add_field => [ "project",   "$PROJECT" ]
       add_field => [ "version",   "$APPVERSION" ]

--- a/docker/rails/sneakers.logger
+++ b/docker/rails/sneakers.logger
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec svlogd -tt /rails/log/sneakers


### PR DESCRIPTION
Get sneakers to log to STDOUT and then capture the log using the init
system. Trying this because otherwise sneakers rotates its own log file
and occassionally breaks the shipping.