### PR TITLE
Correct RepresentativeType spelling error

### DIFF
--- a/app/services/representative_type.rb
+++ b/app/services/representative_type.rb
@@ -6,7 +6,7 @@ module RepresentativeType
     'trade_union'              => 'Union',
     'solicitor'                => 'Solicitor',
     'private_individual'       => 'Private Individual',
-    'trade_association'        => 'Trade Assosciation',
+    'trade_association'        => 'Trade Association',
     'other'                    => 'Other'
   }.freeze
   private_constant :MAPPINGS

--- a/spec/services/representative_type_spec.rb
+++ b/spec/services/representative_type_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RepresentativeType, type: :service do
     'trade_union'              => 'Union',
     'solicitor'                => 'Solicitor',
     'private_individual'       => 'Private Individual',
-    'trade_association'        => 'Trade Assosciation',
+    'trade_association'        => 'Trade Association',
     'other'                    => 'Other' }
 
   describe '::TYPES' do


### PR DESCRIPTION
Trade Association was spelt incorrectly & as it is validated against the
schema it can cause claims to fail validation and not be sent through to
Jadu.