### PR TITLE
Use Travis CI container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
+sudo: false
 language: ruby
 rvm:
 - 2.2.0
 node_js:
 - '0.10'
 addons:
+  apt:
+    packages:
+      - pdftk
   postgresql: '9.3'
 before_script:
 - npm install
@@ -11,6 +15,3 @@ before_script:
 env:
   global:
     secure: FNL+FZauJ7fy1rT4luEvPGuAErxyp4BicM5bXCD/dBHMNI6rhGDulMhnqdThAaR4DvhCXaBahrnNFs7gfilpdkQzz3zYVBqvjlyx4slIL6xRTKOwVo6X6tG804ZiJ2b8sMTCqBBn5xoVCjDcle+VCcQNp2oq/LoXGGPHdx/LcKY=
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq pdftk

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: ruby
 rvm:
 - 2.2.0
+cache: bundler
 node_js:
 - '0.10'
 addons:


### PR DESCRIPTION
Should be able to benefit from faster build start times along with
faster builds by updating the config to use addon->packages
configuration option for pdftk.

See: http://docs.travis-ci.com/user/migrating-from-legacy/