### PR TITLE
Fixes rabbitmq heartbeat timeouts

### DIFF
--- a/config/initializers/amqp.rb
+++ b/config/initializers/amqp.rb
@@ -8,6 +8,7 @@ if Rails.env.production?
     durable: true,
     handler: Sneakers::Handlers::Maxretry,
     log:     STDOUT,
+    heartbeat: 28,
     timeout_job_after: Integer(ENV.fetch('SNEAKERS_TIMEOUT_S')),
     retry_timeout: Integer(ENV.fetch('SNEAKERS_RETRY_TTL_MS')), #milliseconds
     max_retries: Integer(ENV.fetch('SNEAKERS_MAX_RETRIES')),

--- a/lib/tasks/sneakers.rake
+++ b/lib/tasks/sneakers.rake
@@ -15,7 +15,8 @@ namespace :sneakers do
         from_queue klass.queue_name,
                      :headers => {
                        :'x-dead-letter-exchange' => "#{klass.queue_name}-retry"
-                     }
+                     },
+                     :heartbeat => 28
 
       end)
     end


### PR DESCRIPTION
There used to be heartbeat timeouts during workload and initial
handshake in the rabbitmq. This manifested to issues where ActiveJobs
were not being enqueued properly into rabbitmq, for example claims were
being marked as submitted while never having made it into the queues.

Adding the changes just to `config/initializers/amqp.rb` was not enough 
as reconfiguring the heartbeat timeout happens early during handshake
so it was picking the 2 second default timeout specified by sneakers.

Problem details
----------

During a heartbeat definition of 28 seconds, two heartbeats will be sent in the total of 28 seconds and the responses must have been retrieved. This number is configurable on both server side and client side, and during the connection handshake this is negotiated on both sides so that a common value can be agreed upon. Eg:
```
2015-12-14T13:47:39Z p-23595 t-oxq11jlp0 DEBUG: Heartbeat interval negotiation: client = 30, server = 30, result = 30
2015-12-14T13:47:39Z p-23595 t-oxq11jlp0 INFO: Heartbeat interval used (in seconds): 30
2015-12-14T13:47:39Z p-23595 t-oxq11jlp0 DEBUG: Sent connection.tune-ok with heartbeat interval = 30, frame_max = 131072, channel_max = 65535
```

However the sneakers hardcoded default is 2 seconds (presumably set with low latency non-cloud machines in mind) which caused the previous negotiations to send heartbeats at 0.4 second intervals:
`2015-09-09T18:09:05Z p-68 t-oujpb78qk DEBUG: Sending a heartbeat, last activity time: 2015-09-09 18:08:57 +0000, interval (s): 0.4`
There might be an issue in sneakers as well whereby it miscalculates the value too. Here's a sample negotiation with 2 seconds: 
```
2015-12-03T14:57:15Z p-68 t-oujonbc7k DEBUG: Heartbeat interval negotiation: client = 2, server = 30, result = 2
2015-12-03T14:57:15Z p-68 t-oujonbc7k INFO: Heartbeat interval used (in seconds): 2
```

Also while this is configured in amqp.rb and does get applied to sneakers workers (eventually), it appears that perhaps the connections are opened before this configuration has taken place, so by that time the connections have already negotiated a very low heartbeat, which caused also the workers to behave unexpectedly. Also this is a mutual agreement so I believe both the server and the client can reset the connection. In practice I was seeing connections being reset every 6 seconds in rabbitmq log. 

The root cause why we were seeing this only sometimes instead of all the time is simply because sometimes these connections/handshakes/heartbeats were taking *slightly* longer (remember they have to make it all the way to ELB and back into rabbitmq as they are elb-balanced) whereas other times the performance was fast enough to not hit the issue.
