### PR TITLE
Add payment gateway task logging

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -114,6 +114,7 @@ class Claim < ActiveRecord::Base
   end
 
   def payment_applicable?
+    Rails.logger.info "Claim #{self.id} #{self.application_reference} payment_applicable gw: #{PaymentGateway.available?} fee_to_pay? #{fee_to_pay?} fee_group_reference #{fee_group_reference?} "
     PaymentGateway.available? && fee_to_pay? && fee_group_reference?
   end
 


### PR DESCRIPTION
Adds logging to the payment gateway when the state changes from
available = true to false and vice versa. This should allow someone
to detect whether the gateway ever becomes unavailable
(spoiler alert: it does become unavailable often).

