### PR TITLE
Updating links to help with fees info

### DIFF
--- a/app/views/claims/_your_fee.html.slim
+++ b/app/views/claims/_your_fee.html.slim
@@ -21,4 +21,4 @@ fieldset
       input_html: { :class => 'reveal-publish-publisher ga-vpv'},
       reveal: { true => 'main', false => 'main' }
 
-    #remission_applied_info.panel-indent.toggle-content.reveal-subscribe data-target="main" data-show-array="true" = t('.remission_applied_info_html', form: 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160-eng-2015.10.pdf')
+    #remission_applied_info.panel-indent.toggle-content.reveal-subscribe data-target="main" data-show-array="true" = t('.remission_applied_info_html', form: 'https://www.gov.uk/help-with-court-fees')

--- a/app/views/guides/markdown/reducing_fees.md
+++ b/app/views/guides/markdown/reducing_fees.md
@@ -1,8 +1,8 @@
 ##Reducing fees
 
-To pay a lower fee or no fee (known as ‘fee remission’), you’ll need to prove that:
+You may not have to pay a fee, or you may get some money off if you're on a low income or receiving certain benefits, and have a small amount of savings and investments. To be eligible for help with fees, you’ll need to prove that:
 
-1.  In most cases you (and your partner if you have one) have less than £3000 in savings and investments. This is known as ‘disposable capital’ and doesn’t include your main home, personal belongings, wages or benefits.
+1.  In most cases you (and your partner if you have one) have less than £3,000 in savings and investments. This doesn’t include your main home, personal belongings, wages or benefits.
 
 
 2.  You’re either on benefits or have a low income.
@@ -11,16 +11,16 @@ To pay a lower fee or no fee (known as ‘fee remission’), you’ll need to pr
 
 If you receive any of these benefits, you won't have to pay a fee:
 
-* Income-based Jobseeker’s Allowance
-* Income-related Employment and Support Allowance
+* Jobseeker’s Allowance (JSA)
+* Employment and Support Allowance (ESA)
 * Income Support
-* Universal Credit (with gross annual earnings of less than £6,000)
-* State Pension Credit - Guarantee Credit
-* Scottish Civil Legal Aid (not ‘advice and assistance’ or ‘advice by way of representation’)
+* Universal Credit
+* Pension Credit (Guarantee Credit)
+* Scottish Civil Legal Aid
 
 ### Low income
 
-If your monthly income (before tax and other deductions) is equal to or less than the amount set out below, you won’t have to pay a fee.
+If you earn less a month than the amounts in the table below (before tax and National Insurance has been taken off) then you won't have to pay a fee. This can include benefits, eg working tax credit, child tax credit.
 
 |Number of children|If you’re single|If you have a partner|
 |------------------|----------------|---------------------|
@@ -30,15 +30,15 @@ If your monthly income (before tax and other deductions) is equal to or less tha
 
 If you have 3 or more children there’s an extra allowance of £245 for each child.
 
-If your monthly income (before tax and other deductions) is more than these amounts you’ll have to pay £5 towards your fee for every £10 of income you earn above the threshold.
+If your monthly income (before tax and National Insurance has been taken off) is more than these amounts you’ll have to pay £5 towards your fee for every £10 of income you earn above the threshold.
 
 <a name="applying_for_a_fee_reduction"></a>
-### Applying for a fee reduction
-Download and complete a <a href="http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160-eng-2015.10.pdf" rel="external">fee remission form</a>. If claiming in England or Wales, email your completed remission form and evidence to <a href="mailto:eremissions@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
+### Applying for help with fees 
+Apply for help with fees by completing the applicaion form at <a href="https://www.gov.uk/help-with-court-fees" rel="external">www.gov.uk/help-with-court-fees</a>. If you're in England or Wales, you can email your completed application form to <a href="mailto:eremissions@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
 
-If claiming in Scotland (or you would prefer to post your form), you can find the relevant address in the <a href="http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf" rel="external">fee remission form guide</a>.
+If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.  
 
-You will be given another opportunity to apply for fee remission at the end of the claim.
+You will be given another opportunity to apply for help with fees at the end of the claim.
 
 If your case reaches a tribunal, you’ll need to apply for help with paying your hearing fee separately.
 

--- a/config/locales/claim_confirmation.en.yml
+++ b/config/locales/claim_confirmation.en.yml
@@ -14,7 +14,7 @@ en:
         apply_for_remission: |
           You have started an application for help with fees.
           You must complete your application within 7 days or your claim may be rejected.
-        remission_link_text: Complete help with fees application
+        remission_link_text: Complete an application for help with fees
         send_to_respondent: |
           A copy of the claim will be sent to the respondent.
           They’ll have 28 days to reply.
@@ -22,9 +22,9 @@ en:
           We’ll contact you when we’ve sent your claim to the respondent and
           explain the next steps.
         next_steps_remission_england_wales_html: |
-          If claiming in England or Wales, email your completed help with fees application to <a href="mailto:eREMISSIONS@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
+          If claiming in England or Wales, email your completed application for help with fees to <a href="mailto:eREMISSIONS@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
         next_steps_remission_scotland_html: |
-          If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address. 
+          If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
         next_steps_final_step: |
           We’ll review your application for help with fees and let you know the outcome.
 

--- a/config/locales/claim_confirmation.en.yml
+++ b/config/locales/claim_confirmation.en.yml
@@ -12,9 +12,9 @@ en:
         header: What happens next
         payment_failed: We’ll contact you within 5 working days to arrange payment.
         apply_for_remission: |
-          You have started an application for fee remission.
+          You have started an application for help with fees.
           You must complete your application within 7 days or your claim may be rejected.
-        remission_link_text: Complete fee remission application
+        remission_link_text: Complete help with fees application
         send_to_respondent: |
           A copy of the claim will be sent to the respondent.
           They’ll have 28 days to reply.
@@ -22,11 +22,11 @@ en:
           We’ll contact you when we’ve sent your claim to the respondent and
           explain the next steps.
         next_steps_remission_england_wales_html: |
-          If claiming in England or Wales, email your completed fee remission application and evidence to <a href="mailto:eREMISSIONS@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
+          If claiming in England or Wales, email your completed help with fees application to <a href="mailto:eREMISSIONS@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
         next_steps_remission_scotland_html: |
-          If claiming in Scotland (or you would prefer to post your form), you can find the relevant address in the <a href="http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf" rel="external">fee remission form guide</a>.
+          If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address. 
         next_steps_final_step: |
-          We’ll review your fee remission application and let you know the outcome.
+          We’ll review your application for help with fees and let you know the outcome.
 
       download_application:
         header: Download your claim

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -33,13 +33,13 @@ en:
       remission_review: :claim_confirmations.show.what_happens_next.next_steps_final_step
 
        # SPECIFIC TO TEXT EMAIL
-      apply_for_fee_remission_text: 'COMPLETE FEE REMISSION APPLICATION: https://www.employmenttribunals.service.gov.uk/remissions'
+      apply_for_fee_remission_text: 'COMPLETE AN APPLICATION FOR HELP WITH FEES: https://www.employmenttribunals.service.gov.uk/remissions'
       remission_we_will_contact_you_england_wales_text: |
-        If claiming in England or Wales, email your completed fee remission application and evidence to eREMISSIONS@hmcts.gsi.gov.uk.
+        If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk.
       remission_we_will_contact_you_scotland_text: |
-        If claiming in Scotland (or you would prefer to post your form), you can find the relevant address in the fee remission form guide.
+        If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
 
-        FEE REMISSION FORM GUIDE: http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf.
+        GUIDE TO APPLYING FOR HELP WITH FEES: https://www.gov.uk/help-with-court-fees
 
       details:
         header: Submission details
@@ -65,6 +65,6 @@ en:
 
     shared:
       button_fee_remission:
-        apply_for_fee_remission: Complete fee remission application
+        apply_for_fee_remission: Complete an application for help with fees 
       button_complete_claim:
         complete_claim: 'Complete claim'

--- a/spec/features/confirmation_page_spec.rb
+++ b/spec/features/confirmation_page_spec.rb
@@ -57,11 +57,10 @@ RSpec.feature 'Confirmation page', type: :feature do
         expect(page).to have_text 'You have started an application for help with fees. You must complete your application within 7 days or your claim may be rejected.'
         expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.employmenttribunals.service.gov.uk/remissions'
         expect(page).to have_link 'eREMISSIONS@hmcts.gsi.gov.uk', href: 'mailto:eREMISSIONS@hmcts.gsi.gov.uk'
-        expect(page).to have_text 'If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
 
-        If claiming in Scotland (or you would prefer to post your form), you can find the relevant address in the fee remission form guide.'
+        expect(page).to have_text "If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk. If you're in Scotland (or you would prefer to post your form), see the guide to applying for help with fees for the address."
+        expect(page).to have_link 'guide to applying for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
 
-        expect(page).to have_link 'Guide to applying for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
         expect(page).to have_link 'Save a copy', href: pdf_path
         expect(page).to have_text 'Claim submitted'
         expect(page).to_not have_text 'Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU'
@@ -84,11 +83,9 @@ RSpec.feature 'Confirmation page', type: :feature do
         expect(page).to have_text 'You have started an application for help with fees. You must complete your application within 7 days or your claim may be rejected.'
         expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.employmenttribunals.service.gov.uk/remissions'
         expect(page).to have_link 'eREMISSIONS@hmcts.gsi.gov.uk', href: 'mailto:eREMISSIONS@hmcts.gsi.gov.uk'
-        expect(page).to have_text 'If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk.
+        expect(page).to have_text "If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk. If you're in Scotland (or you would prefer to post your form), see the guide to applying for help with fees for the address."
+        expect(page).to have_link 'guide to applying for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
 
-        If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.'
-
-        expect(page).to have_link 'Guide to applying for help with fees', href: 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf'
         expect(page).to have_link 'Save a copy', href: pdf_path
         expect(page).to have_text 'Issue fee paid' '£250.00'
         expect(page).to have_text 'If you have any questions, contact the Public Enquiry Line'

--- a/spec/features/confirmation_page_spec.rb
+++ b/spec/features/confirmation_page_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Confirmation page', type: :feature do
 
     scenario 'viewing the confirmation page' do
       expect(page).to_not have_text 'We’ll contact you within 5 working days to arrange payment.'
-      expect(page).to_not have_link 'Complete fee remission application'
+      expect(page).to_not have_link 'Complete an application for help with fees'
 
       expect(page).to have_link 'Save a copy', href: pdf_path
       expect(page).to have_text 'Claim submitted' 'Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU'
@@ -54,14 +54,14 @@ RSpec.feature 'Confirmation page', type: :feature do
       let(:claim) { create :claim, :single_claimant, :not_submitted, :remission_only }
 
       scenario 'viewing the confirmation page' do
-        expect(page).to have_text 'You have started an application for fee remission. You must complete your application within 7 days or your claim may be rejected.'
-        expect(page).to have_link 'Complete fee remission application', href: 'https://www.employmenttribunals.service.gov.uk/remissions'
+        expect(page).to have_text 'You have started an application for help with fees. You must complete your application within 7 days or your claim may be rejected.'
+        expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.employmenttribunals.service.gov.uk/remissions'
         expect(page).to have_link 'eREMISSIONS@hmcts.gsi.gov.uk', href: 'mailto:eREMISSIONS@hmcts.gsi.gov.uk'
-        expect(page).to have_text 'If claiming in England or Wales, email your completed fee remission application and evidence to eREMISSIONS@hmcts.gsi.gov.uk.
+        expect(page).to have_text 'If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
 
         If claiming in Scotland (or you would prefer to post your form), you can find the relevant address in the fee remission form guide.'
 
-        expect(page).to have_link 'fee remission form guide', href: 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf'
+        expect(page).to have_link 'Guide to applying for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
         expect(page).to have_link 'Save a copy', href: pdf_path
         expect(page).to have_text 'Claim submitted'
         expect(page).to_not have_text 'Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU'
@@ -81,14 +81,14 @@ RSpec.feature 'Confirmation page', type: :feature do
       before { complete_payment }
 
       scenario 'viewing the confirmation page' do
-        expect(page).to have_text 'You have started an application for fee remission. You must complete your application within 7 days or your claim may be rejected.'
-        expect(page).to have_link 'Complete fee remission application', href: 'https://www.employmenttribunals.service.gov.uk/remissions'
+        expect(page).to have_text 'You have started an application for help with fees. You must complete your application within 7 days or your claim may be rejected.'
+        expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.employmenttribunals.service.gov.uk/remissions'
         expect(page).to have_link 'eREMISSIONS@hmcts.gsi.gov.uk', href: 'mailto:eREMISSIONS@hmcts.gsi.gov.uk'
-        expect(page).to have_text 'If claiming in England or Wales, email your completed fee remission application and evidence to eREMISSIONS@hmcts.gsi.gov.uk.
+        expect(page).to have_text 'If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk.
 
-        If claiming in Scotland (or you would prefer to post your form), you can find the relevant address in the fee remission form guide.'
+        If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.'
 
-        expect(page).to have_link 'fee remission form guide', href: 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf'
+        expect(page).to have_link 'Guide to applying for help with fees', href: 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf'
         expect(page).to have_link 'Save a copy', href: pdf_path
         expect(page).to have_text 'Issue fee paid' '£250.00'
         expect(page).to have_text 'If you have any questions, contact the Public Enquiry Line'

--- a/spec/features/create_claim_applications_spec.rb
+++ b/spec/features/create_claim_applications_spec.rb
@@ -254,7 +254,7 @@ feature 'Claim applications', type: :feature do
       expect(page).to have_text     "Claim submitted"
       expect(page).not_to have_text "Fee paid"
       expect(page).not_to have_text "Fee to pay"
-      expect(page).to have_text     "Complete fee remission application"
+      expect(page).to have_text     'Complete an application for help with fees'
       expect(page).not_to have_signout_button
       expect(page).not_to have_session_prompt
     end
@@ -295,7 +295,7 @@ feature 'Claim applications', type: :feature do
         complete_a_claim seeking_remissions: true
         click_button 'Submit claim', exact: true
 
-        expect(page).to have_text 'Complete fee remission application'
+        expect(page).to have_text 'Complete an application for help with fees'
         expect(page).not_to have_text 'You now need to pay the issue fee'
       end
 
@@ -327,7 +327,7 @@ feature 'Claim applications', type: :feature do
         complete_a_claim additional_claimants: true, seeking_remissions: 2
         click_button 'Submit claim', exact: true
 
-        expect(page).to have_text 'Complete fee remission application'
+        expect(page).to have_text 'Complete an application for help with fees'
         expect(page).not_to have_text 'You now need to pay the issue fee'
       end
     end

--- a/spec/mailers/base_mailer_spec.rb
+++ b/spec/mailers/base_mailer_spec.rb
@@ -105,13 +105,13 @@ describe BaseMailer, type: :mailer do
         end
 
         it 'shows remission help' do
-          expect(email).to match_pattern(/complete fee remission application/i, escape_regex: false)
-          expect(email).to match_pattern('If claiming in England or Wales, email your completed fee remission application and evidence to')
+          expect(email).to match_pattern(/complete an application for help with fees/, escape_regex: false)
+          expect(email).to match_pattern('If you're in England or Wales, you can email your completed application form to')
           expect(email).to match_pattern('eREMISSIONS@hmcts.gsi.gov.uk')
-          expect(email).to match_pattern('If claiming in Scotland (or you would prefer to post your form), you can find the relevant address in the ')
-          expect(email).to match_pattern('fee remission form guide')
+          expect(email).to match_pattern('f you're in Scotland (or you would prefer to post your form), see the')
+          expect(email).to match_pattern('guide to applying for help with fees')
           expect(email).to match_pattern('http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf')
-          expect(email).to match_pattern('We’ll review your fee remission application and let you know the outcome.')
+          expect(email).to match_pattern('We’ll review your application for help with fees and let you know the outcome.')
         end
 
         it 'does not show any payment information' do

--- a/spec/mailers/base_mailer_spec.rb
+++ b/spec/mailers/base_mailer_spec.rb
@@ -105,12 +105,12 @@ describe BaseMailer, type: :mailer do
         end
 
         it 'shows remission help' do
-          expect(email).to match_pattern(/complete an application for help with fees/, escape_regex: false)
-          expect(email).to match_pattern('If you're in England or Wales, you can email your completed application form to')
+          expect(email).to match_pattern(/complete an application for help with fees/i, escape_regex: false)
+          expect(email).to match_pattern("If claiming in England or Wales, email your completed application for help with fees to")
           expect(email).to match_pattern('eREMISSIONS@hmcts.gsi.gov.uk')
-          expect(email).to match_pattern('f you're in Scotland (or you would prefer to post your form), see the')
+          expect(email).to match_pattern("If you're in Scotland (or you would prefer to post your form), see the")
           expect(email).to match_pattern('guide to applying for help with fees')
-          expect(email).to match_pattern('http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-2015.10.pdf')
+          expect(email).to match_pattern('https://www.gov.uk/help-with-court-fees')
           expect(email).to match_pattern('We’ll review your application for help with fees and let you know the outcome.')
         end
 


### PR DESCRIPTION
Also, changing some instance of ‘fee remission’ to the new product name
‘ help with fees’