### PR TITLE
Fix for a old link

### DIFF
--- a/app/views/claim_confirmations/show.html.slim
+++ b/app/views/claim_confirmations/show.html.slim
@@ -20,7 +20,7 @@ header.main-header role="banner"
             p= t('.what_happens_next.apply_for_remission')
 
             p= link_to t('.what_happens_next.remission_link_text'),
-                  'https://www.employmenttribunals.service.gov.uk/remissions',
+                  'https://gov.uk/help-with-court-fees',
                   class: 'button'
           li
             p= t('.what_happens_next.next_steps_remission_england_wales_html')

--- a/app/views/claims/_your_fee.html.slim
+++ b/app/views/claims/_your_fee.html.slim
@@ -21,4 +21,4 @@ fieldset
       input_html: { :class => 'reveal-publish-publisher ga-vpv'},
       reveal: { true => 'main', false => 'main' }
 
-    #remission_applied_info.panel-indent.toggle-content.reveal-subscribe data-target="main" data-show-array="true" = t('.remission_applied_info_html', form: 'https://www.gov.uk/help-with-court-fees')
+    #remission_applied_info.panel-indent.toggle-content.reveal-subscribe data-target="main" data-show-array="true" = t('.remission_applied_info_html', form: 'https://gov.uk/help-with-court-fees')

--- a/app/views/guides/markdown/reducing_fees.md
+++ b/app/views/guides/markdown/reducing_fees.md
@@ -33,10 +33,10 @@ If you have 3 or more children there’s an extra allowance of £245 for each ch
 If your monthly income (before tax and National Insurance has been taken off) is more than these amounts you’ll have to pay £5 towards your fee for every £10 of income you earn above the threshold.
 
 <a name="applying_for_a_fee_reduction"></a>
-### Applying for help with fees 
-Apply for help with fees by completing the applicaion form at <a href="https://www.gov.uk/help-with-court-fees" rel="external">www.gov.uk/help-with-court-fees</a>. If you're in England or Wales, you can email your completed application form to <a href="mailto:eremissions@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
+### Applying for help with fees
+Apply for help with fees by completing the applicaion form at <a href="https://gov.uk/help-with-court-fees" rel="external">www.gov.uk/help-with-court-fees</a>. If you're in England or Wales, you can email your completed application form to <a href="mailto:eremissions@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
 
-If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.  
+If you're in Scotland (or you would prefer to post your form), see the <a href="https://gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
 
 You will be given another opportunity to apply for help with fees at the end of the claim.
 

--- a/config/locales/claim_confirmation.en.yml
+++ b/config/locales/claim_confirmation.en.yml
@@ -24,7 +24,7 @@ en:
         next_steps_remission_england_wales_html: |
           If claiming in England or Wales, email your completed application for help with fees to <a href="mailto:eREMISSIONS@hmcts.gsi.gov.uk">eREMISSIONS@hmcts.gsi.gov.uk</a>.
         next_steps_remission_scotland_html: |
-          If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
+          If you're in Scotland (or you would prefer to post your form), see the <a href="https://gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
         next_steps_final_step: |
           We’ll review your application for help with fees and let you know the outcome.
 

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -37,9 +37,9 @@ en:
       remission_we_will_contact_you_england_wales_text: |
         If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk.
       remission_we_will_contact_you_scotland_text: |
-        If you're in Scotland (or you would prefer to post your form), see the <a href="https://www.gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
+        If you're in Scotland (or you would prefer to post your form), see the <a href="https://gov.uk/help-with-court-fees" rel="external">guide to applying for help with fees</a> for the address.
 
-        GUIDE TO APPLYING FOR HELP WITH FEES: https://www.gov.uk/help-with-court-fees
+        GUIDE TO APPLYING FOR HELP WITH FEES: https://gov.uk/help-with-court-fees
 
       details:
         header: Submission details
@@ -65,6 +65,6 @@ en:
 
     shared:
       button_fee_remission:
-        apply_for_fee_remission: Complete an application for help with fees 
+        apply_for_fee_remission: Complete an application for help with fees
       button_complete_claim:
         complete_claim: 'Complete claim'

--- a/spec/features/confirmation_page_spec.rb
+++ b/spec/features/confirmation_page_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 RSpec.feature 'Confirmation page', type: :feature do
@@ -55,7 +56,7 @@ RSpec.feature 'Confirmation page', type: :feature do
 
       scenario 'viewing the confirmation page' do
         expect(page).to have_text 'You have started an application for help with fees. You must complete your application within 7 days or your claim may be rejected.'
-        expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.employmenttribunals.service.gov.uk/remissions'
+        expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
         expect(page).to have_link 'eREMISSIONS@hmcts.gsi.gov.uk', href: 'mailto:eREMISSIONS@hmcts.gsi.gov.uk'
 
         expect(page).to have_text "If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk. If you're in Scotland (or you would prefer to post your form), see the guide to applying for help with fees for the address."
@@ -81,7 +82,7 @@ RSpec.feature 'Confirmation page', type: :feature do
 
       scenario 'viewing the confirmation page' do
         expect(page).to have_text 'You have started an application for help with fees. You must complete your application within 7 days or your claim may be rejected.'
-        expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.employmenttribunals.service.gov.uk/remissions'
+        expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
         expect(page).to have_link 'eREMISSIONS@hmcts.gsi.gov.uk', href: 'mailto:eREMISSIONS@hmcts.gsi.gov.uk'
         expect(page).to have_text "If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk. If you're in Scotland (or you would prefer to post your form), see the guide to applying for help with fees for the address."
         expect(page).to have_link 'guide to applying for help with fees', href: 'https://www.gov.uk/help-with-court-fees'

--- a/spec/features/confirmation_page_spec.rb
+++ b/spec/features/confirmation_page_spec.rb
@@ -56,11 +56,11 @@ RSpec.feature 'Confirmation page', type: :feature do
 
       scenario 'viewing the confirmation page' do
         expect(page).to have_text 'You have started an application for help with fees. You must complete your application within 7 days or your claim may be rejected.'
-        expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
+        expect(page).to have_link 'Complete an application for help with fees', href: 'https://gov.uk/help-with-court-fees'
         expect(page).to have_link 'eREMISSIONS@hmcts.gsi.gov.uk', href: 'mailto:eREMISSIONS@hmcts.gsi.gov.uk'
 
         expect(page).to have_text "If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk. If you're in Scotland (or you would prefer to post your form), see the guide to applying for help with fees for the address."
-        expect(page).to have_link 'guide to applying for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
+        expect(page).to have_link 'guide to applying for help with fees', href: 'https://gov.uk/help-with-court-fees'
 
         expect(page).to have_link 'Save a copy', href: pdf_path
         expect(page).to have_text 'Claim submitted'
@@ -82,10 +82,10 @@ RSpec.feature 'Confirmation page', type: :feature do
 
       scenario 'viewing the confirmation page' do
         expect(page).to have_text 'You have started an application for help with fees. You must complete your application within 7 days or your claim may be rejected.'
-        expect(page).to have_link 'Complete an application for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
+        expect(page).to have_link 'Complete an application for help with fees', href: 'https://gov.uk/help-with-court-fees'
         expect(page).to have_link 'eREMISSIONS@hmcts.gsi.gov.uk', href: 'mailto:eREMISSIONS@hmcts.gsi.gov.uk'
         expect(page).to have_text "If claiming in England or Wales, email your completed application for help with fees to eREMISSIONS@hmcts.gsi.gov.uk. If you're in Scotland (or you would prefer to post your form), see the guide to applying for help with fees for the address."
-        expect(page).to have_link 'guide to applying for help with fees', href: 'https://www.gov.uk/help-with-court-fees'
+        expect(page).to have_link 'guide to applying for help with fees', href: 'https://gov.uk/help-with-court-fees'
 
         expect(page).to have_link 'Save a copy', href: pdf_path
         expect(page).to have_text 'Issue fee paid' '£250.00'

--- a/spec/mailers/base_mailer_spec.rb
+++ b/spec/mailers/base_mailer_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require "rails_helper"
 
 describe BaseMailer, type: :mailer do
@@ -110,7 +111,7 @@ describe BaseMailer, type: :mailer do
           expect(email).to match_pattern('eREMISSIONS@hmcts.gsi.gov.uk')
           expect(email).to match_pattern("If you're in Scotland (or you would prefer to post your form), see the")
           expect(email).to match_pattern('guide to applying for help with fees')
-          expect(email).to match_pattern('https://www.gov.uk/help-with-court-fees')
+          expect(email).to match_pattern('https://gov.uk/help-with-court-fees')
           expect(email).to match_pattern('We’ll review your application for help with fees and let you know the outcome.')
         end
 


### PR DESCRIPTION
The content was updated, but the old URL was left in.

This change fixes that.