### PR TITLE
Add basic rake task to report sidekiq queue status

### DIFF
--- a/lib/tasks/sidekiq_stats.rake
+++ b/lib/tasks/sidekiq_stats.rake
@@ -1,0 +1,16 @@
+require 'sidekiq/api'
+
+desc 'report basic sidekiq stats'
+task :sidekiq_stats do
+  stats = Sidekiq::Stats.new
+
+  log_info = {
+      '@timestamp' => Time.new.getutc.iso8601,
+      'enqueued' => stats.enqueued,
+      'retry_size' => stats.retry_size,
+      'scheduled_size' => stats.scheduled_size,
+      'queues' => stats.queues
+  }
+
+  puts log_info.to_json
+end


### PR DESCRIPTION
The task will be cron'd so that sidekiq status info
can be logged and shipped to kibana.

bundle exec rake sidekiq_stats >> /var/log/sidekiq_log.json 