### PR TITLE
Get protective award opt. to appear on review page

### DIFF
--- a/app/presenters/claim_type_presenter.rb
+++ b/app/presenters/claim_type_presenter.rb
@@ -6,6 +6,10 @@ class ClaimTypePresenter < Presenter
       claims << I18n.t("simple_form.labels.claim_type.is_unfair_dismissal")
     end
 
+    if is_protective_award
+      claims << I18n.t("simple_form.labels.claim_type.is_protective_award")
+    end
+
     claims.push *target.pay_claims.
       map { |c| I18n.t "simple_form.options.claim_type.pay_claims.#{c}" }
 
@@ -17,6 +21,10 @@ class ClaimTypePresenter < Presenter
 
   def is_whistleblowing
     yes_no target.is_whistleblowing
+  end
+
+  def is_protective_award
+    yes_no target.is_protective_award
   end
 
   def send_claim_to_whistleblowing_entity

--- a/app/views/claims/_additional_claimants_upload.html.slim
+++ b/app/views/claims/_additional_claimants_upload.html.slim
@@ -23,7 +23,7 @@ fieldset
 
     #step_one.clearfix
       b = t ".step_one_header"
-      p = t(".download_template_html", path: "/apply/assets/group-claims-template.csv")
+      p = t(".download_template_html", path: "/assets/group-claims-template.csv")
       p = t ".dob_info"
 
     #step_two.clearfix

--- a/config/locales/claim_review.en.yml
+++ b/config/locales/claim_review.en.yml
@@ -104,6 +104,7 @@ en:
       claim_type:
         types: Type(s)
         is_whistleblowing: Whistleblowing
+        is_protective_award: Protective Award
         send_claim_to_whistleblowing_entity: Send to whistleblowing body
 
       claim_details:

--- a/spec/presenters/claim_type_presenter_spec.rb
+++ b/spec/presenters/claim_type_presenter_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe ClaimTypePresenter, type: :presenter do
 
   let(:claim_detail) do
     double 'claim_detail',
-      is_unfair_dismissal: true, discrimination_claims: [:sex_including_equal_pay, :race, :sexual_orientation],
+      is_unfair_dismissal: true, is_protective_award: false,
+      discrimination_claims: [:sex_including_equal_pay, :race, :sexual_orientation],
       pay_claims: [:redundancy, :other], other_claim_details: "yo\r\nyo",
       is_whistleblowing: true, send_claim_to_whistleblowing_entity: false
   end
@@ -18,6 +19,7 @@ RSpec.describe ClaimTypePresenter, type: :presenter do
     it 'concatenates is_unfair_dismissal, discrimination_claims, and pay_claims' do
       expect(subject.types).to eq(
         type_text('Unfair dismissal (including constructive dismissal)') +
+        type_text('Protective Award') +
         type_text('Redundancy pay') +
         type_text('Other payments') +
         type_text('Sex (including equal pay) discrimination') +
@@ -29,4 +31,5 @@ RSpec.describe ClaimTypePresenter, type: :presenter do
 
   its(:is_whistleblowing) { is_expected.to eq("Yes") }
   its(:send_claim_to_whistleblowing_entity) { is_expected.to eq("No") }
+  its(:is_protective_award) { is_expected.to eq("No") }
 end


### PR DESCRIPTION
If a user selects protetive award this option now appears on the claim
review page

Also fixed the additional claimants csv download link.