### PR TITLE
Add enqueued submission count to sidekiq stats

### DIFF
--- a/lib/tasks/sidekiq_stats.rake
+++ b/lib/tasks/sidekiq_stats.rake
@@ -1,16 +1,19 @@
 require 'sidekiq/api'
 
 desc 'report basic sidekiq stats'
-task :sidekiq_stats do
+task :sidekiq_stats => :environment do
   stats = Sidekiq::Stats.new
+
+  enqueued_submissions = Claim.where(state: :enqueued_for_submission).where('submitted_at < ?', 20.minute.ago).count
 
   log_info = {
       '@timestamp' => Time.new.getutc.iso8601,
       'enqueued' => stats.enqueued,
       'retry_size' => stats.retry_size,
       'scheduled_size' => stats.scheduled_size,
-      'queues' => stats.queues
+      'queues' => stats.queues,
+      'enqueued_submissions' => enqueued_submissions
   }
-
   puts log_info.to_json
+
 end


### PR DESCRIPTION
The rake task that retrieves sidekiq stats now reports the number of ET
claims that have not been successfully submitted to Jadu