### PR TITLE
Make app GMT/BST timezone aware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module App
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/spec/features/claim_xml_generation_spec.rb
+++ b/spec/features/claim_xml_generation_spec.rb
@@ -42,7 +42,7 @@ feature 'Generating XML for a claim', type: :feature do
       end
 
       it 'has a TimeStamp equal to the current time' do
-        expect(xpath('//DocumentId/TimeStamp')).to eq '2014-09-29T00:00:00Z'
+        expect(xpath('//DocumentId/TimeStamp')).to eq '2014-09-29T00:00:00+01:00'
       end
 
       it 'has a Version' do
@@ -115,7 +115,7 @@ feature 'Generating XML for a claim', type: :feature do
     end
 
     it 'has a DateOfReceiptEt' do
-      expect(xpath('//DateOfReceiptEt')).to eq '2014-09-29T00:00:00Z'
+      expect(xpath('//DateOfReceiptEt')).to eq '2014-09-29T00:00:00+01:00'
     end
 
     describe 'RemissionIndicated element' do
@@ -266,7 +266,7 @@ feature 'Generating XML for a claim', type: :feature do
         end
 
         it 'has a Date' do
-          expect(xpath('//Payment/Fee/Date')).to eq '2014-09-29T00:00:00Z'
+          expect(xpath('//Payment/Fee/Date')).to eq '2014-09-29T00:00:00+01:00'
         end
       end
 
@@ -282,7 +282,7 @@ feature 'Generating XML for a claim', type: :feature do
             expect(xpath('//Payment/Receipt/Amount')).to eq '250'
           end
           it 'has a Date' do
-            expect(xpath('//Payment/Receipt/Date')).to eq '2014-09-29T00:00:00Z'
+            expect(xpath('//Payment/Receipt/Date')).to eq '2014-09-29T00:00:00+01:00'
           end
         end
 

--- a/spec/presenters/pdf_form/base_delegator_spec.rb
+++ b/spec/presenters/pdf_form/base_delegator_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe PdfForm::BaseDelegator, type: :presenter do
 
   describe '#format_date' do
     it 'returns a date in the format DD/MM/YYYY' do
-      travel_to(Date.new 2014, 9, 29) do
+      travel_to(DateTime.new 2014, 9, 29, 0, 0, 0) do
         expect(subject.format_date(Time.now)).to eq "29/09/2014"
       end
     end


### PR DESCRIPTION
The app is not timezone aware, so in BST the times are still shown to be UTC.

These changes make the app TZ aware.  However, they also alter the date format presented to Jadu, so it's important enough testing is done to confirm that Jadu and underlying services such as CGI support this format.  If not, then some amends will be required to to apply the timezone offset but present a UTC date and time to external services.