### PR TITLE
Add submit buttons to admin

### DIFF
--- a/app/admin/claim.rb
+++ b/app/admin/claim.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register Claim do
   filter :submitted_at
+  filter :state
 
   # no edit, destory, create, etc
   config.clear_action_items!
@@ -29,12 +30,32 @@ ActiveAdmin.register Claim do
     redirect_to :back, notice: 'Generating a new PDF'
   end
 
+  member_action :submit_claim, method: :post do
+    if resource.enqueued_for_submission?
+      ClaimSubmissionJob.perform_later resource
+      resource.create_event Event::MANUALLY_SUBMITTED, actor: 'admin'
+    end
+
+    redirect_to :back, notice: 'Claim submitted to Jadu'
+  end
+
+  member_action :mark_submitted, method: :post do
+    resource.finalize!
+    resource.create_event Event::MANUAL_STATUS_CHANGE, actor: "admin", message: "status changed to submitted"
+
+    redirect_to :back, notice: 'Claim marked as submitted'
+  end
+
   member_action :txt_file, method: :get do
     text = case params[:type]
-           when 'claim_details'              then resource.claim_details
-           when 'miscellaneous_information'  then resource.miscellaneous_information
-           when 'other_claim_details'        then resource.other_claim_details
-           when 'other_outcome'              then resource.other_outcome
+           when 'claim_details' then
+             resource.claim_details
+           when 'miscellaneous_information' then
+             resource.miscellaneous_information
+           when 'other_claim_details' then
+             resource.other_claim_details
+           when 'other_outcome' then
+             resource.other_outcome
            end
 
     send_data text, filename: "#{resource.reference}-#{params[:type]}.txt"
@@ -71,6 +92,16 @@ ActiveAdmin.register Claim do
         link_to "#{text.humanize}", { action: :txt_file, type: text }, { class: :button }
       end
     end
+
+    if resource.enqueued_for_submission?
+      { mark_submitted: "Mark as submitted",
+       submit_claim: "Submit claim" }.each do |action, text|
+        br
+        div do
+          div { button_to text, action: action }
+        end
+      end
+    end
   end
 
   # Show
@@ -79,8 +110,8 @@ ActiveAdmin.register Claim do
       attributes_table_for claim do
         row(:id)
         row('Submitted to JADU') { |c| c.submitted? ? c.submitted_at : 'No' }
-        row('Payment required')  { |c| c.fee_to_pay? ? 'Yes' : 'No' }
-        row('Payment received')  { |c| c.payment_present? ? 'Yes' : 'No' }
+        row('Payment required') { |c| c.fee_to_pay? ? 'Yes' : 'No' }
+        row('Payment received') { |c| c.payment_present? ? 'Yes' : 'No' }
         row :fee_group_reference
 
         row('FGR postcode') do |c|

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,6 +12,8 @@ class Event < ActiveRecord::Base
   PAYMENT_UNCERTAIN           = 'payment_uncertain'.freeze
   PAYMENT_DECLINED            = 'payment_declined'.freeze
   PDF_GENERATED               = 'pdf_generated'.freeze
+  MANUAL_STATUS_CHANGE        = 'manual_status_change'.freeze
+  MANUALLY_SUBMITTED          = 'manually_submitted'.freeze
 
   belongs_to :claim
 


### PR DESCRIPTION
We have situations where a claim may need to be manually resubmitted to
jadu, or simply marked as submitted (to silence alerts).

Two buttons have been added to the admin screen - one to resubmit a
claim and another to mark a claim as submitted.  In both instances an event
is recorded against the claim to indicate that the action was triggered
by an admin user.