### PR TITLE
Fix protective_award display on claim review page

### DIFF
--- a/app/presenters/claim_type_presenter.rb
+++ b/app/presenters/claim_type_presenter.rb
@@ -23,10 +23,6 @@ class ClaimTypePresenter < Presenter
     yes_no target.is_whistleblowing
   end
 
-  def is_protective_award
-    yes_no target.is_protective_award
-  end
-
   def send_claim_to_whistleblowing_entity
     yes_no target.send_claim_to_whistleblowing_entity
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,10 +86,10 @@ ActiveRecord::Schema.define(version: 20161013151741) do
     t.string   "additional_claimants_csv"
     t.integer  "remission_claimant_count",              default: 0
     t.integer  "additional_claimants_csv_record_count", default: 0
-    t.string   "application_reference",                                 null: false
+    t.string   "application_reference",                              null: false
     t.integer  "payment_attempts",                      default: 0
     t.string   "pdf"
-    t.string   "confirmation_email_recipients",         default: [],                 array: true
+    t.string   "confirmation_email_recipients",         default: [],              array: true
     t.boolean  "is_protective_award",                   default: false
   end
 

--- a/spec/presenters/claim_type_presenter_spec.rb
+++ b/spec/presenters/claim_type_presenter_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe ClaimTypePresenter, type: :presenter do
     it 'concatenates is_unfair_dismissal, discrimination_claims, and pay_claims' do
       expect(subject.types).to eq(
         type_text('Unfair dismissal (including constructive dismissal)') +
-        type_text('Protective Award') +
         type_text('Redundancy pay') +
         type_text('Other payments') +
         type_text('Sex (including equal pay) discrimination') +
@@ -31,5 +30,5 @@ RSpec.describe ClaimTypePresenter, type: :presenter do
 
   its(:is_whistleblowing) { is_expected.to eq("Yes") }
   its(:send_claim_to_whistleblowing_entity) { is_expected.to eq("No") }
-  its(:is_protective_award) { is_expected.to eq("No") }
+
 end


### PR DESCRIPTION
The protective award option shows as seleted on the claim review page
even if not selected by the user. This commit fixes that bug.