### PR TITLE
Fix failing tests due to change of event ordering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'spring'
   gem "activerecord-nulldb-adapter"
+  gem 'timecop'
 end
 
 gem 'webmock', group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,6 +501,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.8.1)
     timers (4.0.1)
       hitimes
     turbolinks (2.5.3)
@@ -587,6 +588,7 @@ DEPENDENCIES
   spring
   state_machine
   susy
+  timecop
   turbolinks
   uglifier (>= 1.3.0)
   uk_postcode
@@ -594,3 +596,6 @@ DEPENDENCIES
   virtus
   webmock
   zendesk_api
+
+BUNDLED WITH
+   1.11.2

--- a/spec/features/admin_panel/admin_show_feature_spec.rb
+++ b/spec/features/admin_panel/admin_show_feature_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature 'Viewing a claims details in the admin interface', type: :feature 
     click_button 'Mark as submitted'
     expect(enqueued_claim.reload.state).to eq 'submitted'
 
-    event = enqueued_claim.events.last
+    event = enqueued_claim.events.reload.last
 
     expect(event.claim_state).to eq 'submitted'
     expect(event.event).to eq Event::MANUAL_STATUS_CHANGE
@@ -145,8 +145,7 @@ RSpec.feature 'Viewing a claims details in the admin interface', type: :feature 
 
     click_button 'Submit claim'
 
-    event = enqueued_claim.events.last
-
+    event = enqueued_claim.events.reload.last
     expect(event.event).to eq Event::MANUALLY_SUBMITTED
     expect(event.actor).to eq 'admin'
   end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -548,7 +548,7 @@ RSpec.describe Claim, type: :claim do
   end
 
   describe '#create_event' do
-    let(:event) { subject.events.last }
+    let(:event) { subject.events.first }
 
     it 'creates an event on the claim with the current state of the claim' do
       subject.create_event 'lel', message: 'funny'

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.describe Stats::ClaimStats, type: :model do
 
   describe 'scopes' do
+    subject do
+      Timecop.freeze(current_time) do
+        described_class
+      end
+    end
+
+    let!(:current_time)                     { Time.now }
     let!(:started_claim)                    { create :claim, :not_submitted }
     let!(:old_started_claim)                { create :claim, :not_submitted, created_at: 91.days.ago }
     let!(:old_out_of_range_started_claim)   { create :claim, :not_submitted, created_at: 92.days.ago }
@@ -13,7 +20,8 @@ RSpec.describe Stats::ClaimStats, type: :model do
 
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
-        results = described_class.started_within_max_submission_timeframe
+        results = subject.started_within_max_submission_timeframe
+
         expect(results.size).to eq 2
 
         query_result_record = results.first
@@ -23,7 +31,7 @@ RSpec.describe Stats::ClaimStats, type: :model do
 
     describe '.completed_within_max_submission_timeframe' do
       it 'returns claims completed within the past 91 days' do
-        results = described_class.completed_within_max_submission_timeframe
+        results = subject.completed_within_max_submission_timeframe
         expect(results.size).to eq 2
 
         query_result_record = results.first


### PR DESCRIPTION
Four tests were failing because of a change of the default ordering of
the Event model. This commit fixes those tests.