### PR TITLE
I should not see text “optional” on claim type page.

### DIFF
--- a/app/views/claims/_claim_type.html.slim
+++ b/app/views/claims/_claim_type.html.slim
@@ -11,7 +11,8 @@ fieldset
       p= t '.unfair_dismissal_summary_detail'
   = f.input :is_unfair_dismissal,
     as: :gds_check_boxes,
-    wrapper_class: 'options'
+    wrapper_class: 'options',
+    required: true
 
 fieldset
   legend.medium= t '.protective_award'
@@ -22,7 +23,8 @@ fieldset
       p= t '.protective_award_summary_detail'
   = f.input :is_protective_award,
     as: :gds_check_boxes,
-    wrapper_class: 'options'
+    wrapper_class: 'options',
+    required: true
 
 fieldset
   legend.medium= t '.discrimination'
@@ -45,7 +47,8 @@ fieldset.reveal-publish-delegate
     as: :gds_check_boxes,
     wrapper_class: 'options',
     input_html: { :class => 'reveal-publish-publisher',
-                  :'data-target' => 'sub1'}
+                  :'data-target' => 'sub1' },
+    required: true
 
   = f.input :other_claim_details, as: :text, label: false,
     input_html: { rows: 2 },
@@ -61,7 +64,8 @@ fieldset
     item_wrapper_class: 'block-label',
     input_html: { class: 'reveal-publish-publisher ga-vpv'},
     wrapper_class: 'form-group-reveal reveal-publish-delegate',
-    reveal: { true => 'sub2', false => 'sub2' }
+    reveal: { true => 'sub2', false => 'sub2' },
+    required: true
 
   = f.input :send_claim_to_whistleblowing_entity,
     as: :radio_buttons,
@@ -71,4 +75,5 @@ fieldset
     wrapper_html: { :id => :send_claim_to_whistleblowing_entity_wrapper,
                     :class => 'reveal-subscribe',
                     :'data-target' => 'sub2',
-                    :'data-show-array' => 'true' }
+                    :'data-show-array' => 'true' },
+    required: true

--- a/spec/features/claim_type_page_spec.rb
+++ b/spec/features/claim_type_page_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+feature 'Claim type page' do
+  include FormMethods
+
+  let(:claim) { Claim.create password: 'lollolol' }
+
+  before do
+    visit new_user_session_path
+    fill_in_return_form claim.reference, 'lollolol'
+  end
+
+  describe 'Claim type' do
+    before do
+      visit claim_claim_type_path
+    end
+
+    scenario "I don’t need the words optional against specific types of claim" do
+      expect(page).not_to have_text("Unfair dismissal (including constructive dismissal) (optional)")
+      expect(page).to have_text("Unfair dismissal (including constructive dismissal)")
+
+      expect(page).not_to have_text("Protective Award (optional)")
+      expect(page).to have_text("Protective Award")
+
+      expect(page).not_to have_text("Other type of claim (optional)")
+      expect(page).to have_text("Other type of claim")
+
+      expect(page).not_to have_text("Are you reporting suspected wrongdoing at work? (optional)")
+      expect(page).to have_text("Are you reporting suspected wrongdoing at work?")
+      within(:xpath, ".//fieldset[contains(.,'Whistleblowing claim')]/div[1]") do
+        choose 'Yes'
+      end
+
+      expect(page).not_to have_text("Do you want us to send a copy of your claim to the relevant person or body that deals with whistleblowing? (optional)")
+      expect(page).to have_text("Do you want us to send a copy of your claim to the relevant person or body that deals with whistleblowing?")
+
+      click_button "Save and continue"
+      expect(page).to have_text("Claim details")
+    end
+
+  end
+end


### PR DESCRIPTION
JIRA ticket: https://triadmoj.atlassian.net/browse/RST-13

As a public Employment Tribunal user, I am required to select from a series of options what type of claim(s) I am making, I don’t’ need the words optional against specific types of claim.
AC 1: The text ‘optional’ must not appear against the ‘Unfair dismissal (including constructive dismissal)? option.
AC 2: The text ‘optional’ must not appear against the ‘Protective Award’ option.
AC3: The text ‘optional’ must not appear against the ‘Other claim type?’ option.
AC4: The text ‘optional’ must not appear against the Whistleblowing - ‘Are you reporting suspected wrongdoing at work? option.
AC5: The text ‘optional’ must not appear against the Whistleblowing – ‘Do you want us to send a copy of your claim to the relevant person or body that deals with whistleblowing?