### PR TITLE
Making sure that at least one claim type is submited.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --color
 --require spec_helper
---format documentation
+--format p

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,10 @@ group :development, :test do
   gem 'timecop'
 end
 
-gem 'webmock', group: :test
+group :test do
+  gem 'webmock', group: :test
+  gem 'database_cleaner'
+end
 
 gem 'activeadmin', github: 'activeadmin', ref: '156877'
 gem 'base32_pure'

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'spring'
   gem "activerecord-nulldb-adapter"
-  gem 'timecop'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,7 @@ GEM
     connection_pool (2.2.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
     descendants_tracker (0.0.4)
@@ -553,6 +554,7 @@ DEPENDENCIES
   cocaine
   codeclimate-test-reporter
   compass
+  database_cleaner
   dotenv-rails (= 0.11.1)
   email_validator
   epdq!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,7 +502,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    timecop (0.8.1)
     timers (4.0.1)
       hitimes
     turbolinks (2.5.3)
@@ -590,7 +589,6 @@ DEPENDENCIES
   spring
   state_machine
   susy
-  timecop
   turbolinks
   uglifier (>= 1.3.0)
   uk_postcode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -596,6 +596,3 @@ DEPENDENCIES
   virtus
   webmock
   zendesk_api
-
-BUNDLED WITH
-   1.11.2

--- a/app/forms/claim_type_form.rb
+++ b/app/forms/claim_type_form.rb
@@ -10,6 +10,7 @@ class ClaimTypeForm < Form
   attribute :other_claim_details,                 String
 
   before_validation :reset_claim_details!, unless: :is_other_type_of_claim?
+  validate :presence_of_at_least_one_claim_type
 
   def is_other_type_of_claim
     self.is_other_type_of_claim = other_claim_details.present?
@@ -19,5 +20,23 @@ class ClaimTypeForm < Form
 
   def reset_claim_details!
     self.other_claim_details = nil
+  end
+
+  def presence_of_at_least_one_claim_type
+    self.attributes.keys.each do |attribute_name|
+      claim_type = claim_type_value(attribute_name)
+      return true if claim_type.present?
+    end
+
+    errors.add :base, I18n.t('activemodel.errors.models.claim_type.attributes.blank')
+    false
+  end
+
+  def claim_type_value(attribute_name)
+    claim_type_value = self[attribute_name]
+    if claim_type_value.is_a?(Array)
+      claim_type_value = claim_type_value.select { |field| field.present? }
+    end
+    claim_type_value
   end
 end

--- a/app/forms/claim_type_form.rb
+++ b/app/forms/claim_type_form.rb
@@ -35,7 +35,7 @@ class ClaimTypeForm < Form
   def claim_type_value(attribute_name)
     claim_type_value = self[attribute_name]
     if claim_type_value.is_a?(Array)
-      claim_type_value = claim_type_value.select { |field| field.present? }
+      claim_type_value = claim_type_value.select(&:present?)
     end
     claim_type_value
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -711,6 +711,9 @@ en:
           attributes:
             secondary_respondents:
               too_many: You may have no more than %{max} additional respondents
+        claim_type:
+          attributes:
+            blank: You have to select at least one of the claim types
         claim_details:
           attributes:
             claim_details:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,10 +86,10 @@ ActiveRecord::Schema.define(version: 20161013151741) do
     t.string   "additional_claimants_csv"
     t.integer  "remission_claimant_count",              default: 0
     t.integer  "additional_claimants_csv_record_count", default: 0
-    t.string   "application_reference",                              null: false
+    t.string   "application_reference",                                 null: false
     t.integer  "payment_attempts",                      default: 0
     t.string   "pdf"
-    t.string   "confirmation_email_recipients",         default: [],              array: true
+    t.string   "confirmation_email_recipients",         default: [],                 array: true
     t.boolean  "is_protective_award",                   default: false
   end
 

--- a/spec/features/claim_xml_generation_spec.rb
+++ b/spec/features/claim_xml_generation_spec.rb
@@ -188,7 +188,8 @@ feature 'Generating XML for a claim', type: :feature do
         let(:respondent) { FactoryGirl.create :respondent,
           :without_work_address,
           work_address_telephone_number: nil,
-          address_telephone_number: nil }
+          address_telephone_number: nil
+        }
 
         it_behaves_like "validates against the JADU XSD"
 

--- a/spec/features/claim_xml_generation_spec.rb
+++ b/spec/features/claim_xml_generation_spec.rb
@@ -180,12 +180,13 @@ feature 'Generating XML for a claim', type: :feature do
       end
 
       context 'renders nil elements' do
-        respondent = FactoryGirl.create :respondent,
-          :without_work_address,
-          work_address_telephone_number: nil,
-          address_telephone_number: nil
+        # respondent = FactoryGirl.create :respondent,
+        #   :without_work_address,
+        #   work_address_telephone_number: nil,
+        #   address_telephone_number: nil
 
-        include_context 'assign claim', primary_respondent: respondent
+        include_context 'assign claim'
+
 
         it 'has an AltAddress with empty nodes' do
           expect(doc.xpath('//Respondent/AltAddress/Line')).not_to be_empty

--- a/spec/features/claim_xml_generation_spec.rb
+++ b/spec/features/claim_xml_generation_spec.rb
@@ -187,7 +187,6 @@ feature 'Generating XML for a claim', type: :feature do
 
         include_context 'assign claim'
 
-
         it 'has an AltAddress with empty nodes' do
           expect(doc.xpath('//Respondent/AltAddress/Line')).not_to be_empty
           expect(doc.xpath('//Respondent/AltAddress/Street')).not_to be_empty

--- a/spec/forms/additional_claimants_form_spec.rb
+++ b/spec/forms/additional_claimants_form_spec.rb
@@ -83,12 +83,13 @@ RSpec.describe AdditionalClaimantsForm, :type => :form do
     context 'when there are existing secondary claimants' do
       before do
         2.times { claim.secondary_claimants.create }
+        subject.assign_attributes attributes
+        subject.save
       end
 
       it 'updates the secondary claimants' do
-        subject.assign_attributes attributes
-        subject.save
         claim.secondary_claimants.reload
+        expect(claim.secondary_claimants.count).to eql(2)
 
         attributes[:collection_attributes].each_with_index do |(_, attributes), index|
           attributes.each { |k, v| expect(claim.secondary_claimants[index].send(k)).to eq v }

--- a/spec/forms/claim_type_form_spec.rb
+++ b/spec/forms/claim_type_form_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ClaimTypeForm, :type => :form do
     end
 
     it "is valid with 1 claim type" do
-      subject.discrimination_claims =["", "age"]
+      subject.discrimination_claims = ["", "age"]
       expect(subject.valid?).to be_truthy
     end
 

--- a/spec/forms/claim_type_form_spec.rb
+++ b/spec/forms/claim_type_form_spec.rb
@@ -53,4 +53,38 @@ RSpec.describe ClaimTypeForm, :type => :form do
       end
     end
   end
+
+  describe "claim validation" do
+    before do
+      subject.is_unfair_dismissal = false
+      subject.is_protective_award = false
+      subject.discrimination_claims = [""]
+      subject.pay_claims = [""]
+      subject.is_whistleblowing = false
+      subject.send_claim_to_whistleblowing_entity = false
+      subject.other_claim_details = ""
+    end
+
+    context 'empty attributes' do
+      it "will fail" do
+        expect(subject.valid?).to be_falsey
+      end
+
+      it "will return proper error message" do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:base].first).to eql('You have to select at least one of the claim types')
+      end
+    end
+
+    it "is valid with 1 claim type" do
+      subject.discrimination_claims =["", "age"]
+      expect(subject.valid?).to be_truthy
+    end
+
+    it "is valid with 2 or more claim types" do
+      subject.discrimination_claims = ["", "age"]
+      subject.is_unfair_dismissal = true
+      expect(subject.valid?).to be_truthy
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -548,11 +548,10 @@ RSpec.describe Claim, type: :claim do
   end
 
   describe '#create_event' do
-    let(:event) { subject.events.first }
+    let(:event) { subject.events.where(event: 'lel').first }
 
     it 'creates an event on the claim with the current state of the claim' do
       subject.create_event 'lel', message: 'funny'
-
       { event: 'lel', actor: 'app', message: 'funny', claim_state: 'created' }.each do |k, v|
         expect(event[k]).to eq v
       end

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe Stats::ClaimStats, type: :model do
 
   describe 'scopes' do
-    before do
-      # making sure that we are not in frozen state
-      Timecop.return
-      Timecop.freeze(current_time)
-    end
-    after { Timecop.return }
+    # before do
+    #   # making sure that we are not in frozen state
+    #   Timecop.return
+    #   Timecop.freeze(current_time)
+    # end
+    # after { Timecop.return }
 
     subject { described_class }
 

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Stats::ClaimStats, type: :model do
 
     subject { described_class }
 
-    let!(:current_time)                     { Time.now }
+    let!(:current_time)                     { Time.parse("2017-01-27 13:56:25") }
     let!(:started_claim)                    { create :claim, :not_submitted }
     let!(:old_started_claim)                { create :claim, :not_submitted, created_at: 91.days.ago }
     let!(:old_out_of_range_started_claim)   { create :claim, :not_submitted, created_at: 92.days.ago }

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.describe Stats::ClaimStats, type: :model do
 
   describe 'scopes' do
-    subject do
-      Timecop.freeze(current_time) do
-        described_class
-      end
-    end
+    before { Timecop.freeze(current_time) }
+    after { Timecop.return }
+
+    subject { described_class }
 
     let!(:current_time)                     { Time.now }
     let!(:started_claim)                    { create :claim, :not_submitted }
@@ -20,7 +19,6 @@ RSpec.describe Stats::ClaimStats, type: :model do
 
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
-        expect(Claim.count).to eql(7)
         results = subject.started_within_max_submission_timeframe
         expect(results.reload.size).to eq 2
 

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -3,8 +3,12 @@ require 'rails_helper'
 RSpec.describe Stats::ClaimStats, type: :model do
 
   describe 'scopes' do
-    # before { Timecop.freeze(current_time) }
-    # after { Timecop.return }
+    before do
+      # making sure that we are not in frozen state
+      Timecop.return
+      Timecop.freeze(current_time)
+    end
+    after { Timecop.return }
 
     subject { described_class }
 
@@ -20,7 +24,7 @@ RSpec.describe Stats::ClaimStats, type: :model do
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
         results = subject.started_within_max_submission_timeframe
-        # puts Time.now
+        puts Time.now
         if results.reload.size < 2
           puts subject.all.map(&:created_at)
           puts "---"
@@ -58,34 +62,6 @@ RSpec.describe Stats::ClaimStats, type: :model do
       expect(described_class).
         to receive_message_chain('started_within_max_submission_timeframe.count') { 5 }
       expect(described_class.started_count).to eq 5
-    end
-  end
-
-  describe 'timecop test' do
-    before { Timecop.return }
-    it "time local" do
-      Timecop.freeze("1990-01-14 10:30:00") do
-        expect(Time.now.to_s(:db)).to eql('1990-01-14 10:30:00')
-      end
-    end
-
-    it "time parse" do
-      Timecop.freeze(Time.parse("1995-01-27 13:56:25")) do
-        expect(Time.now.to_s(:db)).to eql('1995-01-27 13:56:25')
-      end
-    end
-
-    it "time local" do
-      t = Time.local(2008, 9, 1, 10, 5, 0)
-      Timecop.travel(t)
-      sleep 3
-      expect(Time.now.to_s(:db)).to eql('2008-09-01 10:05:03')
-    end
-
-    it "Manual stub" do
-      allow(Time).to receive(:now).and_return Time.parse("2008-09-01 10:05:03")
-      expect(Time.now.to_s(:db)).to eql('2008-09-01 10:05:03')
-      expect(92.days.ago.to_s(:db)).to eql("2008-06-01 09:05:03")
     end
   end
 end

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -62,8 +62,9 @@ RSpec.describe Stats::ClaimStats, type: :model do
   end
 
   describe 'timecop test' do
+    before { Timecop.return }
     it "time local" do
-      Timecop.freeze( Time.local(1990, 1, 14, 10, 30)) do
+      Timecop.freeze("1990-01-14 10:30:00") do
         expect(Time.now.to_s(:db)).to eql('1990-01-14 10:30:00')
       end
     end
@@ -79,6 +80,12 @@ RSpec.describe Stats::ClaimStats, type: :model do
       Timecop.travel(t)
       sleep 3
       expect(Time.now.to_s(:db)).to eql('2008-09-01 10:05:03')
+    end
+
+    it "Manual stub" do
+      allow(Time).to receive(:now).and_return Time.parse("2008-09-01 10:05:03")
+      expect(Time.now.to_s(:db)).to eql('2008-09-01 10:05:03')
+      expect(92.days.ago.to_s(:db)).to eql("2008-06-01 09:05:03")
     end
   end
 end

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Stats::ClaimStats, type: :model do
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
         results = subject.started_within_max_submission_timeframe
+        puts Time.now
         if results.reload.size < 2
           puts subject.all.map(&:created_at)
           puts "---"
@@ -34,12 +35,16 @@ RSpec.describe Stats::ClaimStats, type: :model do
 
     describe '.completed_within_max_submission_timeframe' do
       it 'returns claims completed within the past 91 days' do
-        expect(Claim.count).to eql(7)
-        results = subject.completed_within_max_submission_timeframe
-        expect(results.size).to eq 2
+        Timecop.freeze(current_time) do
+          puts Time.now
+          puts 'completed_within_max_submission_timeframe'
+          expect(Claim.count).to eql(7)
+          results = subject.completed_within_max_submission_timeframe
+          expect(results.size).to eq 2
 
-        query_result_record = results.first
-        expect(query_result_record.reference).to eq completed_claim.reference
+          query_result_record = results.first
+          expect(query_result_record.reference).to eq completed_claim.reference
+        end
       end
     end
   end

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe Stats::ClaimStats, type: :model do
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
         results = subject.started_within_max_submission_timeframe
+        if results.reload.size < 2
+          puts subject.all.map(&:created_at)
+          puts "---"
+          puts results.map(&:created_at)
+        end
         expect(results.reload.size).to eq 2
 
         query_result_record = results.first

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe Stats::ClaimStats, type: :model do
 
   describe 'scopes' do
-    before { Timecop.freeze(current_time) }
-    after { Timecop.return }
+    # before { Timecop.freeze(current_time) }
+    # after { Timecop.return }
 
     subject { described_class }
 
@@ -20,7 +20,7 @@ RSpec.describe Stats::ClaimStats, type: :model do
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
         results = subject.started_within_max_submission_timeframe
-        puts Time.now
+        # puts Time.now
         if results.reload.size < 2
           puts subject.all.map(&:created_at)
           puts "---"
@@ -35,16 +35,12 @@ RSpec.describe Stats::ClaimStats, type: :model do
 
     describe '.completed_within_max_submission_timeframe' do
       it 'returns claims completed within the past 91 days' do
-        Timecop.freeze(current_time) do
-          puts Time.now
-          puts 'completed_within_max_submission_timeframe'
-          expect(Claim.count).to eql(7)
-          results = subject.completed_within_max_submission_timeframe
-          expect(results.size).to eq 2
+        expect(Claim.count).to eql(7)
+        results = subject.completed_within_max_submission_timeframe
+        expect(results.size).to eq 2
 
-          query_result_record = results.first
-          expect(query_result_record.reference).to eq completed_claim.reference
-        end
+        query_result_record = results.first
+        expect(query_result_record.reference).to eq completed_claim.reference
       end
     end
   end
@@ -62,6 +58,27 @@ RSpec.describe Stats::ClaimStats, type: :model do
       expect(described_class).
         to receive_message_chain('started_within_max_submission_timeframe.count') { 5 }
       expect(described_class.started_count).to eq 5
+    end
+  end
+
+  describe 'timecop test' do
+    it "time local" do
+      Timecop.freeze( Time.local(1990, 1, 14, 10, 30)) do
+        expect(Time.now.to_s(:db)).to eql('1990-01-14 10:30:00')
+      end
+    end
+
+    it "time parse" do
+      Timecop.freeze(Time.parse("1995-01-27 13:56:25")) do
+        expect(Time.now.to_s(:db)).to eql('1995-01-27 13:56:25')
+      end
+    end
+
+    it "time local" do
+      t = Time.local(2008, 9, 1, 10, 5, 0)
+      Timecop.travel(t)
+      sleep 3
+      expect(Time.now.to_s(:db)).to eql('2008-09-01 10:05:03')
     end
   end
 end

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Stats::ClaimStats, type: :model do
 
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
+        expect(Claim.count).to eql(7)
         results = subject.started_within_max_submission_timeframe
         expect(results.reload.size).to eq 2
 
@@ -30,6 +31,7 @@ RSpec.describe Stats::ClaimStats, type: :model do
 
     describe '.completed_within_max_submission_timeframe' do
       it 'returns claims completed within the past 91 days' do
+        expect(Claim.count).to eql(7)
         results = subject.completed_within_max_submission_timeframe
         expect(results.size).to eq 2
 

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -3,16 +3,14 @@ require 'rails_helper'
 RSpec.describe Stats::ClaimStats, type: :model do
 
   describe 'scopes' do
-    # before do
-    #   # making sure that we are not in frozen state
-    #   Timecop.return
-    #   Timecop.freeze(current_time)
-    # end
-    # after { Timecop.return }
+    before do
+      travel_to(current_time)
+    end
+    after { travel_back }
 
     subject { described_class }
 
-    let!(:current_time)                     { Time.parse("2017-01-27 13:56:25") }
+    let!(:current_time)                     { Time.parse("2010-01-27 13:56:25") }
     let!(:started_claim)                    { create :claim, :not_submitted }
     let!(:old_started_claim)                { create :claim, :not_submitted, created_at: 91.days.ago }
     let!(:old_out_of_range_started_claim)   { create :claim, :not_submitted, created_at: 92.days.ago }
@@ -24,12 +22,6 @@ RSpec.describe Stats::ClaimStats, type: :model do
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
         results = subject.started_within_max_submission_timeframe
-        puts Time.now
-        if results.reload.size < 2
-          puts subject.all.map(&:created_at)
-          puts "---"
-          puts results.map(&:created_at)
-        end
         expect(results.reload.size).to eq 2
 
         query_result_record = results.first

--- a/spec/models/stats/claim_stats_spec.rb
+++ b/spec/models/stats/claim_stats_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe Stats::ClaimStats, type: :model do
     describe '.started_within_max_submission_timeframe' do
       it 'returns claims started within the past 91 days' do
         results = subject.started_within_max_submission_timeframe
-
-        expect(results.size).to eq 2
+        expect(results.reload.size).to eq 2
 
         query_result_record = results.first
         expect(query_result_record.reference).to eq started_claim.reference

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'shoulda/matchers'
+require 'database_cleaner'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -25,21 +26,30 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  # config.use_transactional_fixtures = true
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
+  # ===
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+  # ===
+
   config.infer_spec_type_from_file_location!
 
   config.include ActiveSupport::Testing::TimeHelpers

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,7 @@ RSpec.configure do |config|
 
   config.after(:each) do
     DatabaseCleaner.clean
+    travel_back
   end
   # ===
 


### PR DESCRIPTION
JIRA ticket: https://triadmoj.atlassian.net/browse/RST-12

As a public Employment Tribunal user, I want the system to make it mandatory to select at least one 'claim type', so I can comply with the Employment Tribunal Rules of Procedure for presenting a claim and the correct fee can be applied.

AC 1: The user cannot move to the next page without selecting at least one of the claim data types.
AC 2: Where a user proceeds without selecting a claim data type, system must present an error message.
AC3: Information from the form is stored in the Employment Tribunal database.
AC4: The correct fee has been applied to the ET application. Note: There are no changes required to the fee calculation.