### PR TITLE
Fixing formatting without html_safe.

### DIFF
--- a/app/views/claim_reviews/_item.html.slim
+++ b/app/views/claim_reviews/_item.html.slim
@@ -2,7 +2,7 @@
   tr
     th = t ".#{section_name}.#{name}"
     - if value.present?
-      td = value
+      td = sanitize(value, tags: ['br'])
     - else
       td.not-entered
         = t '.not_entered'


### PR DESCRIPTION
I removed html_safe from presenter helper which then caused wrong rendering of string with <br> tags in. I add sanitising the string and allowing only BR tag so it's still safe.