### PR TITLE
Hotfix/bug fixes refunds

### DIFF
--- a/app/assets/javascripts/modules/moj.date-range.js
+++ b/app/assets/javascripts/modules/moj.date-range.js
@@ -10,48 +10,39 @@ var dateRangeInput = (function() {
     }
 
     function filterMonthSelect(component) {
-        filterMonthsSelectOnStartDate(component);
-        filterMonthsSelectOnEndDate(component);
+        filterMonthsSelect(component);
     }
 
-    function filterMonthsSelectOnStartDate(component) {
-        var monthPart = component.find('[data-part="month"]');
-        var yearPart = component.find('[data-part="year"]');
-        var startDate = component.attr('data-date-range-start');
-        var yearStart = startDate.split('-')[0];
-        if(yearPart.val() === yearStart) {
-            var startMonth = parseInt(startDate.split('-')[1]);
-            monthPart.find('option').each(function(_idx, option) {
-                if(option.value === '') {
-                    return;
-                }
-                if(parseInt(option.value) < startMonth) {
-                    $(option).prop('disabled', true);
-                } else {
-                    $(option).prop('disabled', false);
-                }
-            });
-        }
-    }
-
-    function filterMonthsSelectOnEndDate(component) {
-        var monthPart = component.find('[data-part="month"]');
+    function filterMonthsSelect(component) {
         var yearPart = component.find('[data-part="year"]');
         var endDate = component.attr('data-date-range-end');
+        var startDate = component.attr('data-date-range-start');
+        var yearStart = startDate.split('-')[0];
         var yearEnd = endDate.split('-')[0];
-        if(yearPart.val() === yearEnd) {
-            var endMonth = parseInt(endDate.split('-')[1]);
-            monthPart.find('option').each(function(_idx, option) {
-                if(option.value === '') {
-                    return;
-                }
-                if(parseInt(option.value) > endMonth) {
-                    $(option).prop('disabled', true);
-                } else {
-                    $(option).prop('disabled', false);
-                }
-            });
+        var monthEnd = parseInt(endDate.split('-')[1]);
+        var monthStart = parseInt(startDate.split('-')[1]);
+        if(yearPart.val() == yearStart) {
+            enableMonths(component, monthStart, 12);
+        } else if(yearPart.val() == yearEnd) {
+            enableMonths(component, 1, monthEnd);
+        } else {
+            enableMonths(component, 1,12);
         }
+    }
+
+    function enableMonths(component, startMonth, endMonth) {
+        var monthPart = component.find('[data-part="month"]');
+        monthPart.find('option').each(function(_idx, option) {
+            if(option.value === '') {
+                return;
+            }
+            if(parseInt(option.value) < startMonth || parseInt(option.value) > endMonth) {
+                $(option).prop('disabled', true);
+            } else {
+                $(option).prop('disabled', false);
+            }
+        });
+
     }
 
     dateRangeInput.init = function() {

--- a/app/assets/javascripts/modules/moj.date-range.js
+++ b/app/assets/javascripts/modules/moj.date-range.js
@@ -21,9 +21,9 @@ var dateRangeInput = (function() {
         var yearEnd = endDate.split('-')[0];
         var monthEnd = parseInt(endDate.split('-')[1]);
         var monthStart = parseInt(startDate.split('-')[1]);
-        if(yearPart.val() == yearStart) {
+        if(yearPart.val() === yearStart) {
             enableMonths(component, monthStart, 12);
-        } else if(yearPart.val() == yearEnd) {
+        } else if(yearPart.val() === yearEnd) {
             enableMonths(component, 1, monthEnd);
         } else {
             enableMonths(component, 1,12);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@
 // Page specific
 @import "pages/refunds/profile-selection";
 @import "pages/refunds/refunds-fees";
+@import "pages/refunds/refunds-review";
 
 // MOJDS
 @import "elements/callouts";

--- a/app/assets/stylesheets/pages/refunds/refunds-review.scss
+++ b/app/assets/stylesheets/pages/refunds/refunds-review.scss
@@ -1,0 +1,16 @@
+.main-content.refunds_review {
+  table.review-table.fees {
+    td.fee_type {
+      width: 15%;
+    }
+    td.fee {
+      width: 15%;
+    }
+    td.payment_date {
+      min-width: 8em;
+    }
+    td.payment_method {
+      min-width: 8em;
+    }
+  }
+}

--- a/app/forms/refunds/fees_form.rb
+++ b/app/forms/refunds/fees_form.rb
@@ -2,23 +2,23 @@ module Refunds
   class FeesForm < Form
     PAYMENT_METHODS = ['card', 'cheque', 'cash', 'unknown'].freeze
     VALID_PAYMENT_DATE_RANGE = Date.parse('1 July 2013')..Date.parse('31 August 2017')
-    attribute :et_issue_fee,                            Float
+    attribute :et_issue_fee,                            Integer
     attribute :et_issue_fee_payment_method,             String
     attribute :et_issue_fee_payment_date,               Date
     attribute :et_issue_fee_payment_date_unknown,       Boolean
-    attribute :et_hearing_fee,                          Float
+    attribute :et_hearing_fee,                          Integer
     attribute :et_hearing_fee_payment_method,           String
     attribute :et_hearing_fee_payment_date,               Date
     attribute :et_hearing_fee_payment_date_unknown,       Boolean
-    attribute :eat_issue_fee,                           Float
+    attribute :eat_issue_fee,                           Integer
     attribute :eat_issue_fee_payment_method,            String
     attribute :eat_issue_fee_payment_date,               Date
     attribute :eat_issue_fee_payment_date_unknown,       Boolean
-    attribute :eat_hearing_fee,                         Float
+    attribute :eat_hearing_fee,                         Integer
     attribute :eat_hearing_fee_payment_method,          String
     attribute :eat_hearing_fee_payment_date,               Date
     attribute :eat_hearing_fee_payment_date_unknown,       Boolean
-    attribute :et_reconsideration_fee,                 Float
+    attribute :et_reconsideration_fee,                 Integer
     attribute :et_reconsideration_fee_payment_method,  String
     attribute :et_reconsideration_fee_payment_date,               Date
     attribute :et_reconsideration_fee_payment_date_unknown,       Boolean

--- a/app/views/refunds/_bank_details.html.slim
+++ b/app/views/refunds/_bank_details.html.slim
@@ -1,3 +1,6 @@
+fieldset
+  span = t('.account_help')
+
 = f.input :payment_account_type,
         required: true,
         collection: Refunds::BankDetailsForm::ACCOUNT_TYPES,

--- a/app/views/refunds/_review.html.slim
+++ b/app/views/refunds/_review.html.slim
@@ -119,12 +119,12 @@ div class=("review-list-entry applicant")
     - unless f.object.has_fees?
       p = t('.no_fees')
     - if f.object.has_fees?
-      table.review-table
+      table.review-table.fees
         tr
-          th = t('.fee_type')
-          td = t('.fee')
-          td = "Payment Date"
-          td = t('.payment_method')
+          th.fee_type = t('.fee_type')
+          td.fee = t('.fee')
+          td.payment_date = "Payment Date"
+          td.payment_method = t('.payment_method')
         - if f.object.et_issue_fee_present?
           tr
             th = t('.et_issue_fee')
@@ -157,7 +157,7 @@ div class=("review-list-entry applicant")
             td = payment_method_for(f.object, :eat_hearing_fee)
         tr
           th = t('.total_fees')
-          td = number_to_currency(f.object.total_fees, delimiter: '')
+          td = number_to_currency(f.object.total_fees, delimiter: '', precision: 0)
   div data-behavior= "refund-review-section"
     - if f.object.payment_account_type == 'bank'
       h2.list-header

--- a/app/views/refunds/_review.html.slim
+++ b/app/views/refunds/_review.html.slim
@@ -128,31 +128,31 @@ div class=("review-list-entry applicant")
         - if f.object.et_issue_fee_present?
           tr
             th = t('.et_issue_fee')
-            td = number_to_currency(f.object.et_issue_fee, delimiter: '')
+            td = number_to_currency(f.object.et_issue_fee, delimiter: '', precision: 0)
             td = payment_date_for(f.object, :et_issue_fee)
             td = payment_method_for(f.object, :et_issue_fee)
         - if f.object.et_hearing_fee_present?
           tr
             th = t('.et_hearing_fee')
-            td = number_to_currency(f.object.et_hearing_fee, delimiter: '')
+            td = number_to_currency(f.object.et_hearing_fee, delimiter: '', precision: 0)
             td = payment_date_for(f.object, :et_hearing_fee)
             td = payment_method_for(f.object, :et_hearing_fee)
         - if f.object.et_reconsideration_fee_present?
           tr
             th = t('.et_reconsideration_fee')
-            td = number_to_currency(f.object.et_reconsideration_fee, delimiter: '')
+            td = number_to_currency(f.object.et_reconsideration_fee, delimiter: '', precision: 0)
             td = payment_date_for(f.object, :et_reconsideration_fee)
             td = payment_method_for(f.object, :et_reconsideration_fee)
         - if f.object.eat_issue_fee_present?
           tr
             th = t('.eat_issue_fee')
-            td = number_to_currency(f.object.eat_issue_fee, delimiter: '')
+            td = number_to_currency(f.object.eat_issue_fee, delimiter: '', precision: 0)
             td = payment_date_for(f.object, :eat_issue_fee)
             td = payment_method_for(f.object, :eat_issue_fee)
         - if f.object.eat_hearing_fee_present?
           tr
             th = t('.eat_hearing_fee')
-            td = number_to_currency(f.object.eat_hearing_fee, delimiter: '')
+            td = number_to_currency(f.object.eat_hearing_fee, delimiter: '', precision: 0)
             td = payment_date_for(f.object, :eat_hearing_fee)
             td = payment_method_for(f.object, :eat_hearing_fee)
         tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -850,3 +850,6 @@ en:
             address_post_code:
               blank: Enter the additional respondent's postcode
               invalid: Enter a valid UK postcode. If you live abroad, enter SW55 9QT
+  refunds:
+    bank_details:
+      account_help: "This is the account which must be held in your name where any valid refund repayments will be made"

--- a/config/locales/refunds.yml
+++ b/config/locales/refunds.yml
@@ -321,7 +321,7 @@ en:
                         If you cannot find this number, please use the other information box below to give us any information or reference numbers you think would be helpful in identifying your case
         additional_information: Please use this box to give us any information or reference numbers you think would be helpful in identifying your case
       refunds_bank_details:
-        payment_bank_account_number: Please enter your 8 digit bank account number. This should be a current account in held in your name, not a savings account
+        payment_bank_account_number: Please enter your 8 digit bank account number. This should be a current account held in your name, not a savings account
         payment_bank_sort_code: Please enter the sort code as a six digit number, eg. 112233, please do not include any spaces or dashes
         payment_building_society_account_number: Please enter your 8 digit building society account number. This should be a current account in held in your name, not a savings account
         payment_building_society_sort_code: Please enter the sort code as a six digit number, eg. 112233, please do not include any spaces or dashes

--- a/config/locales/refunds.yml
+++ b/config/locales/refunds.yml
@@ -253,7 +253,7 @@ en:
               blank: Please enter the payment year and month or tick 'Don't know'
               date_range: The payment date must be between %{start_date} and %{end_date}
             base:
-              fees_must_be_positive: You must enter an amount in the relevant fee/s field/s
+              fees_must_be_positive: You must enter a fee in the relevant field
         refunds/bank_details:
           attributes:
             payment_account_type:

--- a/features/step_definitions/refunds/fees_steps.rb
+++ b/features/step_definitions/refunds/fees_steps.rb
@@ -174,5 +174,5 @@ Then(/^I should see only years "([^"]*)" in the year dropdown of all of the fee 
 end
 
 Then(/^the refund fees form should show an error stating that at least one fee should be present$/) do
-  expect(refund_fees_page.form_error_message).to have_text('You must enter an amount in the relevant fee/s field/s')
+  expect(refund_fees_page.form_error_message).to have_text('You must enter a fee in the relevant field')
 end

--- a/features/step_definitions/refunds/setup_steps.rb
+++ b/features/step_definitions/refunds/setup_steps.rb
@@ -35,19 +35,19 @@ And(/^I want a refund for my previous ET claim with case number "1234567\/2016"$
   respondent = OpenStruct.new name: 'Respondent Name',
                               address: respondent_address
 
-  fees = OpenStruct.new et_issue_fee: '1000.00',
+  fees = OpenStruct.new et_issue_fee: '1000',
                         et_issue_payment_method: 'Card',
                         et_issue_payment_date: 'January 2016',
-                        et_hearing_fee: '1001.01',
+                        et_hearing_fee: '1001',
                         et_hearing_payment_method: 'Cash',
                         et_hearing_payment_date: 'February 2016',
-                        eat_issue_fee: '1002.02',
+                        eat_issue_fee: '1002',
                         eat_issue_payment_method: 'Cheque',
                         eat_issue_payment_date: 'March 2016',
-                        eat_hearing_fee: '1003.03',
+                        eat_hearing_fee: '1003',
                         eat_hearing_payment_method: 'Don\'t know',
                         eat_hearing_payment_date: 'April 2016',
-                        et_reconsideration_fee: '1004.04',
+                        et_reconsideration_fee: '1004',
                         et_reconsideration_payment_method: 'Card',
                         et_reconsideration_payment_date: 'Don\'t know'
 
@@ -68,7 +68,7 @@ And(/^I want a refund for my previous ET claim with case number "1234567\/2015"$
   respondent = OpenStruct.new name: 'Respondent Name',
                               address: respondent_address
 
-  fees = OpenStruct.new et_issue_fee: '1000.00',
+  fees = OpenStruct.new et_issue_fee: '1000',
                         et_issue_payment_method: 'Card',
                         et_issue_payment_date: 'April 2016'
 

--- a/spec/forms/refunds/fees_form_spec.rb
+++ b/spec/forms/refunds/fees_form_spec.rb
@@ -268,12 +268,12 @@ module Refunds
         writer_method = "#{fee_name}_fee=".to_sym
         it 'converts an amount from a string' do
           form.send(writer_method, '10.51')
-          expect(form.send(reader_method)).to eql 10
+          expect(form.send(reader_method)).to be 10
         end
 
         it 'converts an amount from a float' do
           form.send(writer_method, 10.51)
-          expect(form.send(reader_method)).to eql 10
+          expect(form.send(reader_method)).to be 10
         end
 
         it 'leaves an invalid number from a string as is' do

--- a/spec/forms/refunds/fees_form_spec.rb
+++ b/spec/forms/refunds/fees_form_spec.rb
@@ -6,7 +6,7 @@ module Refunds
     let(:form) { described_class.new(refund_session) }
 
     it_behaves_like 'a Form', {
-      et_issue_fee: '0.01',
+      et_issue_fee: '12',
       et_issue_fee_payment_method: 'card',
       et_issue_fee_payment_date: { day: '1', month: '1', year: '2016' }
     }, Session
@@ -134,35 +134,35 @@ module Refunds
 
       # Start of validation specs
       context 'with positive fees as float with known date' do
-        include_examples 'a positive fee with known date', fee_name: :et_issue, fee: 0.01
-        include_examples 'a positive fee with known date', fee_name: :et_hearing, fee: 0.01
-        include_examples 'a positive fee with known date', fee_name: :et_reconsideration, fee: 0.01
-        include_examples 'a positive fee with known date', fee_name: :eat_issue, fee: 0.01
-        include_examples 'a positive fee with known date', fee_name: :eat_hearing, fee: 0.01
+        include_examples 'a positive fee with known date', fee_name: :et_issue, fee: 12
+        include_examples 'a positive fee with known date', fee_name: :et_hearing, fee: 12
+        include_examples 'a positive fee with known date', fee_name: :et_reconsideration, fee: 12
+        include_examples 'a positive fee with known date', fee_name: :eat_issue, fee: 12
+        include_examples 'a positive fee with known date', fee_name: :eat_hearing, fee: 12
       end
 
       context 'with positive fees as string with known date' do
-        include_examples 'a positive fee with known date', fee_name: :et_issue, fee: '0.01'
-        include_examples 'a positive fee with known date', fee_name: :et_hearing, fee: '0.01'
-        include_examples 'a positive fee with known date', fee_name: :et_reconsideration, fee: '0.01'
-        include_examples 'a positive fee with known date', fee_name: :eat_issue, fee: '0.01'
-        include_examples 'a positive fee with known date', fee_name: :eat_hearing, fee: '0.01'
+        include_examples 'a positive fee with known date', fee_name: :et_issue, fee: '12'
+        include_examples 'a positive fee with known date', fee_name: :et_hearing, fee: '12'
+        include_examples 'a positive fee with known date', fee_name: :et_reconsideration, fee: '12'
+        include_examples 'a positive fee with known date', fee_name: :eat_issue, fee: '12'
+        include_examples 'a positive fee with known date', fee_name: :eat_hearing, fee: '12'
       end
 
       context 'with positive fees as float with unknown date' do
-        include_examples 'a positive fee with unknown date', fee_name: :et_issue, fee: 0.01
-        include_examples 'a positive fee with unknown date', fee_name: :et_hearing, fee: 0.01
-        include_examples 'a positive fee with unknown date', fee_name: :et_reconsideration, fee: 0.01
-        include_examples 'a positive fee with unknown date', fee_name: :eat_issue, fee: 0.01
-        include_examples 'a positive fee with unknown date', fee_name: :eat_hearing, fee: 0.01
+        include_examples 'a positive fee with unknown date', fee_name: :et_issue, fee: 12
+        include_examples 'a positive fee with unknown date', fee_name: :et_hearing, fee: 12
+        include_examples 'a positive fee with unknown date', fee_name: :et_reconsideration, fee: 12
+        include_examples 'a positive fee with unknown date', fee_name: :eat_issue, fee: 12
+        include_examples 'a positive fee with unknown date', fee_name: :eat_hearing, fee: 12
       end
 
       context 'with positive fees as string with unknown date' do
-        include_examples 'a positive fee with unknown date', fee_name: :et_issue, fee: '0.01'
-        include_examples 'a positive fee with unknown date', fee_name: :et_hearing, fee: '0.01'
-        include_examples 'a positive fee with unknown date', fee_name: :et_reconsideration, fee: '0.01'
-        include_examples 'a positive fee with unknown date', fee_name: :eat_issue, fee: '0.01'
-        include_examples 'a positive fee with unknown date', fee_name: :eat_hearing, fee: '0.01'
+        include_examples 'a positive fee with unknown date', fee_name: :et_issue, fee: '12'
+        include_examples 'a positive fee with unknown date', fee_name: :et_hearing, fee: '12'
+        include_examples 'a positive fee with unknown date', fee_name: :et_reconsideration, fee: '12'
+        include_examples 'a positive fee with unknown date', fee_name: :eat_issue, fee: '12'
+        include_examples 'a positive fee with unknown date', fee_name: :eat_hearing, fee: '12'
       end
 
       context 'with no fees' do
@@ -263,12 +263,44 @@ module Refunds
         end
       end
 
+      shared_examples 'a fee amount writer' do |fee_name:|
+        reader_method = "#{fee_name}_fee".to_sym
+        writer_method = "#{fee_name}_fee=".to_sym
+        it 'converts an amount from a string' do
+          form.send(writer_method, '10.51')
+          expect(form.send(reader_method)).to eql 10
+        end
+
+        it 'converts an amount from a float' do
+          form.send(writer_method, 10.51)
+          expect(form.send(reader_method)).to eql 10
+        end
+
+        it 'leaves an invalid number from a string as is' do
+          form.send(writer_method, 'non-numeric')
+          expect(form.send(reader_method)).to eql 'non-numeric'
+        end
+
+        it 'does not convert nil' do
+          form.send(writer_method, nil)
+          expect(form.send(reader_method)).to be_nil
+        end
+      end
+
       context 'fee date writers' do
         include_examples 'a fee date writer', fee_name: :et_issue
         include_examples 'a fee date writer', fee_name: :et_hearing
         include_examples 'a fee date writer', fee_name: :et_reconsideration
         include_examples 'a fee date writer', fee_name: :eat_issue
         include_examples 'a fee date writer', fee_name: :eat_hearing
+      end
+
+      context 'fee amount writers' do
+        include_examples 'a fee amount writer', fee_name: :et_issue
+        include_examples 'a fee amount writer', fee_name: :et_hearing
+        include_examples 'a fee amount writer', fee_name: :et_reconsideration
+        include_examples 'a fee amount writer', fee_name: :eat_issue
+        include_examples 'a fee amount writer', fee_name: :eat_hearing
       end
     end
   end


### PR DESCRIPTION
A collection of minor bug fixes and styling changes for ET refunds.  The tickets are currently being done, but there is a mad rush for this to go into UAT at 11:30.

Fixed bug fix in fees dropdown for dates - the disabled months were staying disabled even when you changed year.
Fee values are now integers - they didnt want any pence in there
Styling changes on review page
Corrected a wording error on the bank details page
Corrected validation text for when no fees are input
Added help text to repayment details page