### PR TITLE
Hotfix/refund improved validation

### DIFF
--- a/app/forms/refunds/fees_form.rb
+++ b/app/forms/refunds/fees_form.rb
@@ -33,81 +33,57 @@ module Refunds
     validates :et_issue_fee_payment_method,
       presence: true,
       inclusion: PAYMENT_METHODS,
-      if: lambda {
-        et_issue_fee.present? && et_issue_fee.try(:positive?)
-      }
+      if: -> { et_issue_fee.try(:positive?) }
 
     validates :et_issue_fee_payment_date,
       presence: true,
       date: true,
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
-      if: lambda {
-            et_issue_fee.present? &&
-              et_issue_fee.try(:positive?) &&
-              !et_issue_fee_payment_date_unknown?
-          }
+      if: -> { et_issue_fee.try(:positive?) && !et_issue_fee_payment_date_unknown? }
 
     validates :et_hearing_fee_payment_method,
       presence: true,
       inclusion: PAYMENT_METHODS,
-      if: -> { et_hearing_fee.present? && et_hearing_fee.try(:positive?) }
+      if: -> { et_hearing_fee.try(:positive?) }
 
     validates :et_hearing_fee_payment_date,
       presence: true,
       date: true,
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
-      if: lambda {
-            et_hearing_fee.present? && et_hearing_fee.try(:positive?) && !et_hearing_fee_payment_date_unknown?
-          }
+      if: -> { et_hearing_fee.try(:positive?) && !et_hearing_fee_payment_date_unknown? }
 
     validates :et_reconsideration_fee_payment_method,
       presence: true,
       inclusion: PAYMENT_METHODS,
-      if: -> { et_reconsideration_fee.present? && et_reconsideration_fee.try(:positive?) }
+      if: -> {  et_reconsideration_fee.try(:positive?) }
 
     validates :et_reconsideration_fee_payment_date,
       presence: true,
       date: true,
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
-      if: lambda {
-            et_reconsideration_fee.present? &&
-              et_reconsideration_fee.try(:positive?) &&
-              !et_reconsideration_fee_payment_date_unknown?
-          }
+      if: -> { et_reconsideration_fee.try(:positive?) && !et_reconsideration_fee_payment_date_unknown? }
 
     validates :eat_issue_fee_payment_method,
       presence: true,
       inclusion: PAYMENT_METHODS,
-      if: lambda {
-        eat_issue_fee.present? && eat_issue_fee.try(:positive?)
-      }
+      if: -> { eat_issue_fee.try(:positive?) }
 
     validates :eat_issue_fee_payment_date,
       presence: true,
       date: true,
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
-      if: lambda {
-            eat_issue_fee.present? &&
-              eat_issue_fee.try(:positive?) &&
-              !eat_issue_fee_payment_date_unknown?
-          }
+      if: -> { eat_issue_fee.try(:positive?) && !eat_issue_fee_payment_date_unknown? }
 
     validates :eat_hearing_fee_payment_method,
       presence: true,
       inclusion: PAYMENT_METHODS,
-      if: lambda {
-        eat_hearing_fee.present? && eat_hearing_fee.try(:positive?)
-      }
+      if: -> { eat_hearing_fee.try(:positive?) }
 
     validates :eat_hearing_fee_payment_date,
       presence: true,
       date: true,
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
-      if: lambda {
-            eat_hearing_fee.present? &&
-              eat_hearing_fee.try(:positive?) &&
-              !eat_hearing_fee_payment_date_unknown?
-          }
+      if: -> { eat_hearing_fee.try(:positive?) && !eat_hearing_fee_payment_date_unknown? }
 
     validate :validate_fees
 

--- a/app/forms/refunds/fees_form.rb
+++ b/app/forms/refunds/fees_form.rb
@@ -27,13 +27,14 @@ module Refunds
 
     validates :et_issue_fee, :et_hearing_fee, :et_reconsideration_fee,
       :eat_issue_fee, :eat_hearing_fee,
-      numericality: true, allow_blank: true
+      numericality: { greater_than_or_equal_to: 0 },
+      allow_blank: true
 
     validates :et_issue_fee_payment_method,
       presence: true,
       inclusion: PAYMENT_METHODS,
       if: lambda {
-        et_issue_fee.present? && et_issue_fee.positive?
+        et_issue_fee.present? && et_issue_fee.try(:positive?)
       }
 
     validates :et_issue_fee_payment_date,
@@ -42,27 +43,27 @@ module Refunds
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: lambda {
             et_issue_fee.present? &&
-              et_issue_fee.positive? &&
+              et_issue_fee.try(:positive?) &&
               !et_issue_fee_payment_date_unknown?
           }
 
     validates :et_hearing_fee_payment_method,
       presence: true,
       inclusion: PAYMENT_METHODS,
-      if: -> { et_hearing_fee.present? && et_hearing_fee.positive? }
+      if: -> { et_hearing_fee.present? && et_hearing_fee.try(:positive?) }
 
     validates :et_hearing_fee_payment_date,
       presence: true,
       date: true,
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: lambda {
-            et_hearing_fee.present? && et_hearing_fee.positive? && !et_hearing_fee_payment_date_unknown?
+            et_hearing_fee.present? && et_hearing_fee.try(:positive?) && !et_hearing_fee_payment_date_unknown?
           }
 
     validates :et_reconsideration_fee_payment_method,
       presence: true,
       inclusion: PAYMENT_METHODS,
-      if: -> { et_reconsideration_fee.present? && et_reconsideration_fee.positive? }
+      if: -> { et_reconsideration_fee.present? && et_reconsideration_fee.try(:positive?) }
 
     validates :et_reconsideration_fee_payment_date,
       presence: true,
@@ -70,7 +71,7 @@ module Refunds
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: lambda {
             et_reconsideration_fee.present? &&
-              et_reconsideration_fee.positive? &&
+              et_reconsideration_fee.try(:positive?) &&
               !et_reconsideration_fee_payment_date_unknown?
           }
 
@@ -78,7 +79,7 @@ module Refunds
       presence: true,
       inclusion: PAYMENT_METHODS,
       if: lambda {
-        eat_issue_fee.present? && eat_issue_fee.positive?
+        eat_issue_fee.present? && eat_issue_fee.try(:positive?)
       }
 
     validates :eat_issue_fee_payment_date,
@@ -87,7 +88,7 @@ module Refunds
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: lambda {
             eat_issue_fee.present? &&
-              eat_issue_fee.positive? &&
+              eat_issue_fee.try(:positive?) &&
               !eat_issue_fee_payment_date_unknown?
           }
 
@@ -95,7 +96,7 @@ module Refunds
       presence: true,
       inclusion: PAYMENT_METHODS,
       if: lambda {
-        eat_hearing_fee.present? && eat_hearing_fee.positive?
+        eat_hearing_fee.present? && eat_hearing_fee.try(:positive?)
       }
 
     validates :eat_hearing_fee_payment_date,
@@ -104,7 +105,7 @@ module Refunds
       date_range: { range: VALID_PAYMENT_DATE_RANGE, format: '%B %Y' },
       if: lambda {
             eat_hearing_fee.present? &&
-              eat_hearing_fee.positive? &&
+              eat_hearing_fee.try(:positive?) &&
               !eat_hearing_fee_payment_date_unknown?
           }
 
@@ -119,7 +120,7 @@ module Refunds
     end
 
     def validate_fees
-      errors.add(:base, :fees_must_be_positive) unless total_fees.positive?
+      errors.add(:base, :fees_must_be_positive) unless total_fees.try(:positive?)
     end
   end
 end

--- a/config/locales/refunds.yml
+++ b/config/locales/refunds.yml
@@ -229,26 +229,36 @@ en:
               nil_or_empty: Please select Yes or No
         refunds/fees:
           attributes:
+            et_issue_fee:
+              greater_than_or_equal_to: Fee must be greater than %{count}
             et_issue_fee_payment_method:
               blank: Please select a payment method
             et_issue_fee_payment_date:
               blank: Please enter the payment year and month or tick 'Don't know'
               date_range: The payment date must be between %{start_date} and %{end_date}
+            et_hearing_fee:
+              greater_than_or_equal_to: Fee must be greater than %{count}
             et_hearing_fee_payment_method:
               blank: Please select a payment method
             et_hearing_fee_payment_date:
               blank: Please enter the payment year and month or tick 'Don't know'
               date_range: The payment date must be between %{start_date} and %{end_date}
+            et_reconsideration_fee:
+              greater_than_or_equal_to: Fee must be greater than %{count}
             et_reconsideration_fee_payment_method:
               blank: Please select a payment method
             et_reconsideration_fee_payment_date:
               blank: Please enter the payment year and month or tick 'Don't know'
               date_range: The payment date must be between %{start_date} and %{end_date}
+            eat_issue_fee:
+              greater_than_or_equal_to: Fee must be greater than %{count}
             eat_issue_fee_payment_method:
               blank: Please select a payment method
             eat_issue_fee_payment_date:
               blank: Please enter the payment year and month or tick 'Don't know'
               date_range: The payment date must be between %{start_date} and %{end_date}
+            eat_hearing_fee:
+              greater_than_or_equal_to: Fee must be greater than %{count}
             eat_hearing_fee_payment_method:
               blank: Please select a payment method
             eat_hearing_fee_payment_date:

--- a/features/refund_validations_fees.feature
+++ b/features/refund_validations_fees.feature
@@ -19,6 +19,11 @@ Feature: Refund Validations - Fees Page
     Then all fee payment method fields in the fees page should be marked with an error
     Then all fee payment date fields in the fees page should be marked with an error for blank input
 
+  Scenario: A user fills in negative fees
+    And I fill in the refund fee values with negative values
+    And I save the refund fees
+    Then all fee value fields in the fees page should be marked with an error for negative values
+
   Scenario: A user fills in no fees data at all and submits
     And I save the refund fees
     Then the refund fees form should show an error stating that at least one fee should be present

--- a/features/step_definitions/refunds/fees_steps.rb
+++ b/features/step_definitions/refunds/fees_steps.rb
@@ -185,7 +185,6 @@ Then(/^the refund fees form should show an error stating that at least one fee s
   expect(refund_fees_page.form_error_message).to have_text('You must enter a fee in the relevant field')
 end
 
-
 And(/^I fill in the refund fee values with negative values$/) do
   original_claim_fees = refund_fees_page.original_claim_fees
   [:et_issue, :et_hearing, :et_reconsideration, :eat_issue, :eat_hearing].each do |fee|

--- a/features/step_definitions/refunds/fees_steps.rb
+++ b/features/step_definitions/refunds/fees_steps.rb
@@ -30,6 +30,14 @@ Then(/^all fee payment date fields in the fees page should not be marked with an
   expect(refund_fees_page.original_claim_fees.eat_hearing.payment_date).to have_no_error, 'EAT refund payment date should not have an error'
 end
 
+Then(/^all fee value fields in the fees page should be marked with an error for negative values$/) do
+  expect(refund_fees_page.original_claim_fees.et_issue.fee.error.text).to eql 'Fee must be greater than 0'
+  expect(refund_fees_page.original_claim_fees.et_hearing.fee.error.text).to eql 'Fee must be greater than 0'
+  expect(refund_fees_page.original_claim_fees.et_reconsideration.fee.error.text).to eql 'Fee must be greater than 0'
+  expect(refund_fees_page.original_claim_fees.eat_issue.fee.error.text).to eql 'Fee must be greater than 0'
+  expect(refund_fees_page.original_claim_fees.eat_hearing.fee.error.text).to eql 'Fee must be greater than 0'
+end
+
 And(/^I fill in my refund fees and verify the total$/) do
   step('I take a screenshot named "Page 4 - Fees 1"')
   test_user_fees = test_user.et_claim_to_refund.fees
@@ -175,4 +183,12 @@ end
 
 Then(/^the refund fees form should show an error stating that at least one fee should be present$/) do
   expect(refund_fees_page.form_error_message).to have_text('You must enter a fee in the relevant field')
+end
+
+
+And(/^I fill in the refund fee values with negative values$/) do
+  original_claim_fees = refund_fees_page.original_claim_fees
+  [:et_issue, :et_hearing, :et_reconsideration, :eat_issue, :eat_hearing].each do |fee|
+    original_claim_fees.send(fee).fee.set('-1')
+  end
 end

--- a/spec/forms/refunds/fees_form_spec.rb
+++ b/spec/forms/refunds/fees_form_spec.rb
@@ -132,13 +132,11 @@ module Refunds
         end
       end
 
-      shared_examples 'a negative fee' do |fee_name:, fee:|
-        before { form.send("#{fee_name}_fee=", fee) }
-        it 'validates against negative values' do
+      shared_examples 'any fee' do |fee_name:|
+        it 'validates numeric values disallowing negative values' do
           expect(form).to validate_numericality_of("#{fee_name}_fee").
             is_greater_than_or_equal_to(0)
         end
-
       end
 
       # Start of validation specs
@@ -216,12 +214,12 @@ module Refunds
         end
       end
 
-      context 'with negative fees' do
-        include_examples 'a negative fee', fee_name: :et_issue, fee: -1
-        include_examples 'a negative fee', fee_name: :et_hearing, fee: -1
-        include_examples 'a negative fee', fee_name: :et_reconsideration, fee: -1
-        include_examples 'a negative fee', fee_name: :eat_issue, fee: -1
-        include_examples 'a negative fee', fee_name: :eat_hearing, fee: -1
+      context 'common validations per fee' do
+        include_examples 'any fee', fee_name: :et_issue
+        include_examples 'any fee', fee_name: :et_hearing
+        include_examples 'any fee', fee_name: :et_reconsideration
+        include_examples 'any fee', fee_name: :eat_issue
+        include_examples 'any fee', fee_name: :eat_hearing
       end
     end
 

--- a/spec/forms/refunds/fees_form_spec.rb
+++ b/spec/forms/refunds/fees_form_spec.rb
@@ -132,6 +132,15 @@ module Refunds
         end
       end
 
+      shared_examples 'a negative fee' do |fee_name:, fee:|
+        before { form.send("#{fee_name}_fee=", fee) }
+        it 'validates against negative values' do
+          expect(form).to validate_numericality_of("#{fee_name}_fee").
+            is_greater_than_or_equal_to(0)
+        end
+
+      end
+
       # Start of validation specs
       context 'with positive fees as float with known date' do
         include_examples 'a positive fee with known date', fee_name: :et_issue, fee: 12
@@ -205,6 +214,14 @@ module Refunds
           form.valid?
           expect(form.errors[:base]).to include(I18n.t('activemodel.errors.models.refunds/fees.attributes.base.fees_must_be_positive'))
         end
+      end
+
+      context 'with negative fees' do
+        include_examples 'a negative fee', fee_name: :et_issue, fee: -1
+        include_examples 'a negative fee', fee_name: :et_hearing, fee: -1
+        include_examples 'a negative fee', fee_name: :et_reconsideration, fee: -1
+        include_examples 'a negative fee', fee_name: :eat_issue, fee: -1
+        include_examples 'a negative fee', fee_name: :eat_hearing, fee: -1
       end
     end
 


### PR DESCRIPTION
Last night, an issue occured on production where people typed in a pound sign in the fee value (I assume old browsers as it is an html5 number field) and the various places in the form object that checked to see if the number entered was positive was failing because the value was actually a string.

Also, cathie pointed out (no ticket on jira yet) that negative values were also allowed.

This PR fixed both of these by validating the fee is >=0 (zero is allowed - it is the same as blank meaning no fee)