### PR TITLE
feature/rst-660 Populate Claimant Email Correctly

### DIFF
--- a/app/forms/refunds/applicant_form.rb
+++ b/app/forms/refunds/applicant_form.rb
@@ -32,16 +32,16 @@ module Refunds
     attribute :applicant_first_name,         String
     attribute :applicant_last_name,          String
     attribute :applicant_date_of_birth,      Date
-    attribute :email_address, String
+    attribute :applicant_email_address, String
     attribute :applicant_title, String
 
     validates :applicant_title, :applicant_first_name, :applicant_last_name, presence: true
 
     validates :applicant_title, inclusion: { in: TITLES }
     validates :applicant_first_name, :applicant_last_name, length: { maximum: NAME_LENGTH }
-    validates :email_address, allow_blank: true,
-                              email: true,
-                              length: { maximum: EMAIL_ADDRESS_LENGTH }
+    validates :applicant_email_address, allow_blank: true,
+                                        email: true,
+                                        length: { maximum: EMAIL_ADDRESS_LENGTH }
     validates :applicant_address_telephone_number, presence: true
     validates :applicant_date_of_birth, presence: true
     validates :has_name_changed, nil_or_empty: true

--- a/app/forms/refunds/original_case_details_form.rb
+++ b/app/forms/refunds/original_case_details_form.rb
@@ -30,6 +30,7 @@ module Refunds
     attribute :claimant_address_county,                 String
     attribute :claimant_address_post_code,              String
     attribute :claimant_name,                           String
+    attribute :claimant_email_address,                  String
     validates :et_tribunal_office, inclusion: TRIBUNAL_OFFICES, allow_blank: true
     validates :et_country_of_claim, presence: true, inclusion: COUNTRY_OF_CLAIMS
     validates :claim_had_representative, nil_or_empty: true
@@ -50,18 +51,19 @@ module Refunds
       presence: true
     validates :et_case_number, format: { with: %r(\A\d{7}\/\d{4}\z) }, allow_blank: true
     validates :eat_case_number, format: { with: %r(\AUKEAT\/\d{4}\/\d{2}\/\d{3}\z) }, allow_blank: true
-    before_validation :transfer_name
+    before_validation :transfer_personal_info
     before_validation :transfer_address, unless: :address_changed
 
     private
 
-    def transfer_name
+    def transfer_personal_info
       claimant_name = [
         resource.applicant_title&.titleize,
         resource.applicant_first_name,
         resource.applicant_last_name
       ].join(' ')
       self.claimant_name = claimant_name
+      self.claimant_email_address = resource.applicant_email_address
     end
 
     def transfer_address

--- a/app/views/refunds/_applicant.html.slim
+++ b/app/views/refunds/_applicant.html.slim
@@ -34,7 +34,7 @@ fieldset.reveal-subscribe data-target='has_name_changed' data-show-array='false'
   = f.input :applicant_address_post_code, input_html: {class: 'short-input'}
 
   = f.input :applicant_address_telephone_number, as: :tel, input_html: { class: 'medium-input' }
-  = f.input :email_address
+  = f.input :applicant_email_address
 
 fieldset.reveal-subscribe data-target='has_name_changed' data-show-array='true'
   legend= t '.sorry_name_changed.header'

--- a/app/views/refunds/_review.html.slim
+++ b/app/views/refunds/_review.html.slim
@@ -35,8 +35,8 @@ div class=("review-list-entry applicant")
         th = t('simple_form.labels.claimant.address_telephone_number')
         td = f.object.applicant_address_telephone_number
       tr
-        th = t('.email_address')
-        td = f.object.email_address
+        th = t('.applicant_email_address')
+        td = f.object.applicant_email_address
   div data-behavior= "refund-review-section"
     h2.list-header
       span = t ".sections.original_case_details"
@@ -45,6 +45,9 @@ div class=("review-list-entry applicant")
       tr
         th = t('.claimant_name')
         td = f.object.claimant_name
+      tr
+        th = t('.claimant_email_address')
+        td = f.object.claimant_email_address
       tr
         th = t('.claimant_address_building')
         td = f.object.claimant_address_building

--- a/config/locales/refunds.yml
+++ b/config/locales/refunds.yml
@@ -78,7 +78,8 @@ en:
         building_society_details: "Your Building Society Details"
       full_name: "Full Name"
       date_of_birth: "Date Of Birth"
-      email_address: "Email Address"
+      applicant_email_address: "Email Address"
+      claimant_email_address: "Claimant email address"
       edit: "Edit"
       claimant_name: "Claimant name"
       claimant_address_post_code: "Claimant address post code"
@@ -349,6 +350,7 @@ en:
         applicant_first_name: First name
         applicant_last_name: Last name
         applicant_date_of_birth: Date of birth
+        applicant_email_address: Email address
 
       refunds_original_case_details:
         claimant_address_building: Building number or name

--- a/db/migrate/20171127135309_rename_incorrect_fields_in_refunds.rb
+++ b/db/migrate/20171127135309_rename_incorrect_fields_in_refunds.rb
@@ -1,0 +1,18 @@
+class RenameIncorrectFieldsInRefunds < ActiveRecord::Migration
+  class Refund < ActiveRecord::Base
+    self.table_name = :refunds
+  end
+
+  def up
+    rename_column :refunds, :applicant_email_address, :claimant_email_address
+    rename_column :refunds, :email_address, :applicant_email_address
+    Refund.find_each batch_size: 100 do |r|
+      r.claimant_email_address = r.applicant_email_address
+      r.save
+    end
+  end
+  def down
+    rename_column :refunds, :applicant_email_address, :email_address
+    rename_column :refunds, :claimant_email_address, :applicant_email_address
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171006134320) do
+ActiveRecord::Schema.define(version: 20171127135309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,7 +151,7 @@ ActiveRecord::Schema.define(version: 20171006134320) do
   create_table "refunds", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "email_address",                                                                        null: false
+    t.string   "applicant_email_address",                                                              null: false
     t.string   "application_reference",                                                                null: false
     t.integer  "application_reference_number",                                                         null: false
     t.boolean  "address_changed",                                                                      null: false
@@ -200,7 +200,7 @@ ActiveRecord::Schema.define(version: 20171006134320) do
     t.string   "applicant_first_name",                                                                 null: false
     t.string   "applicant_last_name",                                                                  null: false
     t.date     "applicant_date_of_birth"
-    t.string   "applicant_email_address"
+    t.string   "claimant_email_address"
     t.string   "applicant_title",                                                                      null: false
     t.string   "payment_account_type",                                                                 null: false
     t.string   "payment_bank_account_name"

--- a/features/step_definitions/refunds/review_steps.rb
+++ b/features/step_definitions/refunds/review_steps.rb
@@ -31,6 +31,7 @@ end
 And(/^I verify the claimants name and address in the original case details of the refund review page$/) do
   refund_review_page.original_claimant_details do |section|
     expect(section.name.text).to eql "#{test_user.title} #{test_user.first_name} #{test_user.last_name}"
+    expect(section.email_address.text).to eql test_user.email_address.to_s
     expect(section.building.text).to eql test_user.et_claim_to_refund.address.building.to_s
     expect(section.street.text).to eql test_user.et_claim_to_refund.address.street.to_s
     expect(section.locality.text).to eql test_user.et_claim_to_refund.address.locality.to_s

--- a/features/support/page_objects/refund/review_page.rb
+++ b/features/support/page_objects/refund/review_page.rb
@@ -15,6 +15,7 @@ module Refunds
     end
     section :original_claimant_details, :refund_review_section_labelled, 'Original Case Details' do
       element :name, :refund_review_section_field_labelled, 'Claimant name'
+      element :email_address, :refund_review_section_field_labelled, 'Claimant email address'
       element :building, :refund_review_section_field_labelled, 'Claimant address building number or name'
       element :street, :refund_review_section_field_labelled, 'Claimant address street'
       element :locality, :refund_review_section_field_labelled, 'Claimant address town/city'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -227,7 +227,7 @@ FactoryGirl.define do
   end
 
   factory :refund do
-    sequence(:email_address)              { |n| "tester#{n}@domain.com" }
+    sequence(:applicant_email_address)    { |n| "tester#{n}@domain.com" }
     accept_declaration                    true
     address_changed                       true
     has_name_changed                      false

--- a/spec/forms/refunds/applicant_form_spec.rb
+++ b/spec/forms/refunds/applicant_form_spec.rb
@@ -80,27 +80,27 @@ module Refunds
         end
       end
 
-      context 'email_address' do
+      context 'applicant_email_address' do
         it 'allows blank' do
-          applicant_form.email_address = ''
+          applicant_form.applicant_email_address = ''
           applicant_form.valid?
-          expect(applicant_form.errors).not_to include :email_address
+          expect(applicant_form.errors).not_to include :applicant_email_address
         end
 
         it 'validates email - allowing a good email address' do
-          applicant_form.email_address = 'test@test.com'
+          applicant_form.applicant_email_address = 'test@test.com'
           applicant_form.valid?
-          expect(applicant_form.errors).not_to include :email_address
+          expect(applicant_form.errors).not_to include :applicant_email_address
         end
 
         it 'validates email - disallowing a bad email address' do
-          applicant_form.email_address = 'test.com'
+          applicant_form.applicant_email_address = 'test.com'
           applicant_form.valid?
-          expect(applicant_form.errors).to include :email_address
+          expect(applicant_form.errors).to include :applicant_email_address
         end
 
         it 'validates length' do
-          expect(applicant_form).to ensure_length_of(:email_address).is_at_most(100)
+          expect(applicant_form).to ensure_length_of(:applicant_email_address).is_at_most(100)
         end
       end
 

--- a/spec/forms/refunds/original_case_details_form_spec.rb
+++ b/spec/forms/refunds/original_case_details_form_spec.rb
@@ -12,13 +12,83 @@ module Refunds
       {
         applicant_title: 'mr',
         applicant_first_name: 'Test',
-        applicant_last_name: 'User'
+        applicant_last_name: 'User',
+        applicant_email_address: 'test.user@emaildomain.com'
       }.merge(address_attributes)
     end
     let(:session_attributes) { Refund.new(refund_attributes).attributes.to_h }
     let(:refund_session) { double('Session', session_attributes) }
 
     let(:form) { described_class.new(refund_session) }
+
+    describe 'before validations' do
+      context 'without changed address' do
+        let(:address_attributes) do
+          {
+            address_changed: false,
+            applicant_address_building: '102',
+            applicant_address_street: 'Petty France',
+            applicant_address_locality: 'London',
+            applicant_address_county: 'Greater London',
+            applicant_address_post_code: 'SW12 3HQ'
+          }
+        end
+
+        it 'transfers the address' do
+          # Act
+          form.valid?
+
+          # Assert
+          expect(form).to have_attributes claimant_address_building: '102',
+                                          claimant_address_street: 'Petty France',
+                                          claimant_address_locality: 'London',
+                                          claimant_address_county: 'Greater London',
+                                          claimant_address_post_code: 'SW12 3HQ'
+        end
+      end
+
+      context 'with address changed' do
+        let(:address_attributes) do
+          {
+            address_changed: true,
+            applicant_address_building: '102',
+            applicant_address_street: 'Petty France',
+            applicant_address_locality: 'London',
+            applicant_address_county: 'Greater London',
+            applicant_address_post_code: 'SW12 3HQ'
+          }
+        end
+
+        it 'does not transfer the address' do
+          # Act
+          form.valid?
+
+          # Assert
+          expect(form).not_to have_attributes claimant_address_building: '102',
+                                              claimant_address_street: 'Petty France',
+                                              claimant_address_locality: 'London',
+                                              claimant_address_county: 'Greater London',
+                                              claimant_address_post_code: 'SW12 3HQ'
+
+        end
+      end
+
+      it 'transfers personal email' do
+        # Act
+        form.valid?
+
+        # Assert
+        expect(form.claimant_email_address).to eq 'test.user@emaildomain.com'
+      end
+
+      it 'transfers name and titleize the title' do
+        # Act
+        form.valid?
+
+        # Assert
+        expect(form.claimant_name).to eql 'Mr Test User'
+      end
+    end
 
     describe 'validations' do
       context 'et_case_number' do


### PR DESCRIPTION
This PR corrects an issue found by a user of the csv export who noticed only the applicant email existed - no claimant, but everywhere else, the applicants details were duplicated into the claimant (it was designed so that the applicant did not have to be the claimant)
This also highlighted that the email address names were inconsistent - it was not prefixed by the word 'applicant_' like everything else.

So, the following changes have been made in this PR

DB Changes (which will therefore affect the csv output)
what was applicant_email_address is now claimant_email_address
Claimant email address added to review page as it was missing previously
Added safe data migration to populate claimant_email_address of existing records

Improved unit test around the form objects for copying the data conditionally
The relevant form object now copies the applicant email address into the claimant email address

The review page also shows the claimant email address under the claimant name