### PR TITLE
Removed is_claimant column from database - no longer required

### DIFF
--- a/app/forms/refunds/applicant_form.rb
+++ b/app/forms/refunds/applicant_form.rb
@@ -12,7 +12,6 @@ module Refunds
     attribute :applicant_address_county,           String
     attribute :applicant_address_post_code,        String
     attribute :applicant_address_telephone_number, String
-    attribute :is_claimant,              Boolean
     attribute :has_name_changed,         Boolean
 
     validates :applicant_address_building, :applicant_address_street,

--- a/config/locales/refunds.yml
+++ b/config/locales/refunds.yml
@@ -31,8 +31,6 @@ en:
       print_copy: to have a copy of your refund number for reference
     personal_details:
       date_of_birth: Date of birth
-    claimant:
-      is_claimant_legend: "Are you the claimant ?"
     profile_selection:
       header: "Introduction Page"
       please_select_profile: "Introduction Page"

--- a/db/migrate/20171128092945_remove_is_claimant_from_refunds.rb
+++ b/db/migrate/20171128092945_remove_is_claimant_from_refunds.rb
@@ -1,0 +1,9 @@
+class RemoveIsClaimantFromRefunds < ActiveRecord::Migration
+  def up
+    remove_column :refunds, :is_claimant
+  end
+
+  def down
+    add_column :refunds, :is_claimant, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171127135309) do
+ActiveRecord::Schema.define(version: 20171128092945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,7 +226,6 @@ ActiveRecord::Schema.define(version: 20171127135309) do
     t.boolean  "eat_issue_fee_payment_date_unknown"
     t.date     "eat_hearing_fee_payment_date"
     t.boolean  "eat_hearing_fee_payment_date_unknown"
-    t.boolean  "is_claimant"
     t.datetime "submitted_at",                                                                         null: false
     t.text     "eat_case_number",                                                                      null: false
   end

--- a/features/step_definitions/refunds/applicant_steps.rb
+++ b/features/step_definitions/refunds/applicant_steps.rb
@@ -1,7 +1,3 @@
-And(/^I answer Yes to the are you the claimant question for refunds$/) do
-  refund_applicant_page.is_claimant.set("Yes")
-end
-
 And(/^I answer (Yes|No) to the has your name changed question for refunds$/) do |value|
   refund_applicant_page.has_name_changed.set(value)
 end

--- a/features/support/page_objects/refund/applicant_page.rb
+++ b/features/support/page_objects/refund/applicant_page.rb
@@ -3,12 +3,6 @@ module Refunds
     section :form_error_message, '[aria-describedby=error-message]' do |section|
 
     end
-    section :is_claimant, :xpath, (XPath.generate { |x| x.descendant(:fieldset)[x.descendant(:legend)[x.string.n.is("Are you the claimant ?")]] }) do
-      def set(value)
-        choose(value)
-      end
-    end
-
     section :has_name_changed, AppTest::FormBoolean, :simple_form_boolean, 'Has your name changed since you made your employment tribunal claim ?'
 
     section :about_the_claimant, :xpath, (XPath.generate { |x| x.descendant(:fieldset)[x.descendant(:legend)[x.string.n.is("About you")]] }) do


### PR DESCRIPTION
A nice simple PR - to remove the is_claimant column from the database.  It used to be a question we asked on a form, but the question got removed and the database column didn't.