### PR TITLE
The db host is now configurable via the environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,9 +11,9 @@ development:
 
 local:
   <<: *default
-  database: atet_local
-  host: db
-  user: postgres
+  database: <%= ENV['DB_NAME'] || 'atet_local' %>
+  host: <%= ENV['DB_HOST'] || 'db' %>
+  user: <%= ENV.fetch('DB_USERNAME', 'postgres') %>
 
 test: &test
   <<: *default


### PR DESCRIPTION
The db host is now configurable via the environment for use with docker setups using the 'local' environment.