### PR TITLE
Improvement to carrierwave config

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,10 +3,14 @@ require 'carrierwave/storage/fog'
 CarrierWave.configure do |config|
   credentials = {
     provider:              'AWS',
-    region:                'eu-west-1',
+    region:                ENV.fetch('AWS_REGION', 'eu-west-1'),
     aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'] || '',
     aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'] || ''
   }
+
+  credentials.merge!(endpoint: ENV['AWS_ENDPOINT'], host: URI.parse(ENV['AWS_ENDPOINT']).host) if ENV.key?('AWS_ENDPOINT')
+
+  credentials[:path_style] = true if ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'false') == 'true'
 
   config.fog_public      = false
   config.fog_directory   = ENV['S3_UPLOAD_BUCKET']


### PR DESCRIPTION
Improvement to carrierwave config to allow the AWS endpoint and path_style options to be configurable from the environment.  This is for use with a fake s3 service in a docker environment for example.

Note that if these environment variables are not provided, the system operates exactly as it did before - assuming its own defaults etc...