### PR TITLE
Upgrade gems with security issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
     connection_pool (2.2.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    crass (1.0.2)
+    crass (1.0.4)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -283,7 +283,7 @@ GEM
       activesupport (>= 4.0)
       logstash-event (~> 1.2.0)
       request_store
-    loofah (2.1.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.9)
@@ -333,10 +333,10 @@ GEM
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     public_suffix (2.0.5)
-    rack (1.6.8)
+    rack (1.6.10)
     rack-livereload (0.3.15)
       rack
-    rack-protection (1.5.3)
+    rack-protection (1.5.5)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -357,8 +357,8 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (4.2.10)
       actionpack (= 4.2.10)
       activesupport (= 4.2.10)
@@ -580,4 +580,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Security patches for:
- CVE-2018-8048
- CVE-2018-1000119
- CVE-2018-3741
