### PR TITLE
Fixing bug for free text religion value

### DIFF
--- a/app/helpers/diversities_helper.rb
+++ b/app/helpers/diversities_helper.rb
@@ -22,8 +22,11 @@ module DiversitiesHelper
   end
 
   def religion_value(object)
-    return object.religion if object.religion_text.blank?
-    object.religion_text
+    if object.religion_text.blank? && object.religion
+      t("simple_form.options.diversities_religion.religion.#{object.religion}")
+    elsif object.religion_text
+      object.religion_text
+    end
   end
 
   def ethnicity_type_list

--- a/app/views/diversities/_review.html.slim
+++ b/app/views/diversities/_review.html.slim
@@ -55,7 +55,7 @@ div
       th = t('diversities.religion.hint')
       td
         - if religion_value(f.object)
-          = t("simple_form.options.diversities_religion.religion.#{religion_value(f.object)}")
+          = religion_value(f.object)
       td = link_to t('diversities.edit'), diversity_religion_path(return_to_review: true)
     tr
       th = t('diversities.ethnicity.hint')

--- a/spec/helpers/diversities_helper_spec.rb
+++ b/spec/helpers/diversities_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe DiversitiesHelper, type: :helper do
+
+  let(:fee_label) { 'Fee' }
+
+  describe 'religion_value' do
+    context 'when called with empty value' do
+      it do
+        object = instance_double(Diversities::ReligionForm, religion_text: nil, religion: nil)
+        expect(helper.religion_value(object)).to be_nil
+      end
+    end
+
+    context 'when called with religion value' do
+      it 'use the translation key' do
+        object = instance_double(Diversities::ReligionForm, religion_text: nil, religion: 'sikh')
+        expect(helper.religion_value(object)).to eql('Sikh')
+      end
+    end
+
+    context 'when called with free text value' do
+      it 'return the free text value' do
+        object = instance_double(Diversities::ReligionForm, religion_text: 'Jedi', religion: nil)
+        expect(helper.religion_value(object)).to eql('Jedi')
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the religion value was free text it failed to display because there was no translation key that would match the value.