### PR TITLE
Added include_hidden: false to all radio buttons 

### DIFF
--- a/app/views/claims/_additional_claimants_upload.html.slim
+++ b/app/views/claims/_additional_claimants_upload.html.slim
@@ -13,6 +13,7 @@ fieldset
   = f.input :has_additional_claimants,
     hint: t('.has_additional_claimants_html', path: claim_additional_claimants_path),
     as: :radio_buttons,
+    include_hidden: false,
     item_wrapper_class: 'block-label',
     wrapper_class: 'form-group-reveal reveal-publish-delegate',
     input_html: { :class => 'reveal-publish-publisher'},

--- a/app/views/claims/_additional_information.html.slim
+++ b/app/views/claims/_additional_information.html.slim
@@ -7,6 +7,7 @@ fieldset
 
   = f.input :has_miscellaneous_information, label: false,
     as: :radio_buttons,
+    include_hidden: false,
     item_wrapper_class: 'block-label',
     wrapper_html: { :class => 'form-group-reveal reveal-publish-delegate' },
     input_html: { :class => 'reveal-publish-publisher ga-vpv'},

--- a/app/views/claims/_additional_respondents.html.slim
+++ b/app/views/claims/_additional_respondents.html.slim
@@ -4,6 +4,7 @@ fieldset
 
   = f.input :of_collection_type,
     as: :radio_buttons,
+    include_hidden: false,
     label: false,
     item_wrapper_class: 'block-label',
     wrapper_class: 'form-group-reveal reveal-publish-delegate',
@@ -46,6 +47,7 @@ fieldset
                   label:false,
                   collection: RespondentForm::NO_ACAS_REASON,
                   as: :radio_buttons,
+                  include_hidden: false,
                   required: true,
                   item_wrapper_class: 'block-label large-label'
                 span.form-hint.toggle-content.reveal-acas-hint = t '.no_acas_number_note_two'

--- a/app/views/claims/_claim_details.html.slim
+++ b/app/views/claims/_claim_details.html.slim
@@ -27,6 +27,7 @@ fieldset
   legend= t '.similar_claims'
   = f.input :other_known_claimants,
     as: :radio_buttons,
+    include_hidden: false,
     item_wrapper_class: 'block-label',
     wrapper_class: 'form-group-reveal reveal-publish-delegate',
     input_html: { :class => 'reveal-publish-publisher ga-vpv'},

--- a/app/views/claims/_claim_type.html.slim
+++ b/app/views/claims/_claim_type.html.slim
@@ -61,6 +61,7 @@ fieldset
   legend= t '.whistleblowing'
   = f.input :is_whistleblowing,
     as: :radio_buttons,
+    include_hidden: false,
     item_wrapper_class: 'block-label',
     input_html: { class: 'reveal-publish-publisher ga-vpv'},
     wrapper_class: 'form-group-reveal reveal-publish-delegate',
@@ -69,6 +70,7 @@ fieldset
 
   = f.input :send_claim_to_whistleblowing_entity,
     as: :radio_buttons,
+    include_hidden: false,
     item_wrapper_class: 'block-label',
     wrapper_class: 'panel-indent toggle-content',
     input_html: { class: 'ga-vpv'},

--- a/app/views/claims/_claimant.html.slim
+++ b/app/views/claims/_claimant.html.slim
@@ -4,10 +4,12 @@ fieldset
   = render partial: 'personal_details', locals: { f: f }
 
   = f.input :gender, collection: ClaimantForm::GENDERS, as: :radio_buttons,
-    item_wrapper_class: 'block-label'
+    item_wrapper_class: 'block-label',
+    include_hidden: false
 
   = f.input :has_special_needs,
     as: :radio_buttons,
+    include_hidden: false,
     item_wrapper_class: 'block-label',
     wrapper_class: 'form-group-reveal reveal-publish-delegate',
     input_html: { :class => 'reveal-publish-publisher ga-vpv'},
@@ -34,4 +36,5 @@ fieldset
     = f.input :contact_preference,
       collection: ClaimantForm::CONTACT_PREFERENCES,
       as: :radio_buttons,
+      include_hidden: false,
       item_wrapper_class: 'block-label'

--- a/app/views/claims/_employment.html.slim
+++ b/app/views/claims/_employment.html.slim
@@ -4,6 +4,7 @@ fieldset
   /! Radios: main yes / no
   = f.input :was_employed,
     as: :radio_buttons,
+    include_hidden: false,
     item_wrapper_class: 'block-label',
     wrapper_html: { :class => 'form-group-reveal reveal-publish-delegate' },
     input_html: { :class => 'reveal-publish-publisher ga-vpv'},
@@ -17,6 +18,7 @@ fieldset
       = f.input :current_situation, input_html: { class: 'reveal-publish-publisher'}, label: false,
         collection: EmploymentForm::CURRENT_SITUATION,
         as: :radio_buttons,
+        include_hidden: false,
         item_wrapper_class: 'block-label',
         wrapper_html: { :class => 'form-group-reveal' },
         reveal: { 'still_employed'        => 'sub1',
@@ -56,6 +58,7 @@ fieldset
 
           = f.input_field :worked_notice_period_or_paid_in_lieu,
             as: :radio_buttons,
+            include_hidden: false,
             :class => 'reveal-publish-publisher',
             reveal: { true => 'sub2', false => 'sub2' },
             item_wrapper_class: 'block-label '
@@ -70,6 +73,7 @@ fieldset
               = f.input_field :notice_pay_period_count, {type: 'text', class: 'string'}
               = f.input :notice_pay_period_type, label: false,
                 collection: EmploymentForm::NOTICE_PAY_PERIODS, as: :radio_buttons,
+                include_hidden: false,
                 item_wrapper_class: 'slim-label'
 
         = f.input :average_hours_worked_per_week, input_html: { class: 'short-input' }
@@ -89,6 +93,7 @@ fieldset
               label: false,
               collection: EmploymentForm::PAY_PERIODS,
               as: :radio_buttons,
+              include_hidden: false,
               item_wrapper_class: 'slim-label'
 
         = f.input :net_pay,
@@ -101,10 +106,12 @@ fieldset
               label: false,
               collection: EmploymentForm::PAY_PERIODS,
               as: :radio_buttons,
+              include_hidden: false,
               item_wrapper_class: 'slim-label'
 
         = f.input :enrolled_in_pension_scheme,
           as: :radio_buttons,
+          include_hidden: false,
           item_wrapper_class: 'block-label'
 
         = f.input :benefit_details,
@@ -118,6 +125,7 @@ fieldset
 
       = f.input :found_new_job,
         as: :radio_buttons,
+        include_hidden: false,
         item_wrapper_class: 'block-label',
         input_html: { :class => 'reveal-publish-publisher'},
         wrapper_html: { :class => 'form-group-reveal' },
@@ -141,4 +149,5 @@ fieldset
             label: false,
             collection: EmploymentForm::PAY_PERIODS,
             as: :radio_buttons,
+            include_hidden: false,
             item_wrapper_class: 'slim-label'

--- a/app/views/claims/_representative.html.slim
+++ b/app/views/claims/_representative.html.slim
@@ -4,6 +4,7 @@ fieldset
   .reveal-publish-delegate
     = f.input :has_representative,
       as: :radio_buttons,
+      include_hidden: false,
       item_wrapper_class: 'block-label',
       wrapper_class: 'form-group-reveal',
       input_html: { :class => 'reveal-publish-publisher ga-vpv'},

--- a/app/views/claims/_respondent.slim
+++ b/app/views/claims/_respondent.slim
@@ -13,6 +13,7 @@ fieldset
   legend= t '.workaddress_legend'
   = f.input :worked_at_same_address,
     as: :radio_buttons,
+    include_hidden: false,
     wrapper_html: { :class => 'form-group-reveal reveal-publish-delegate'},
     item_wrapper_class: 'block-label',
     input_html: { :class => 'reveal-publish-publisher ga-vpv' },
@@ -45,6 +46,7 @@ fieldset.acas
       = f.input :no_acas_number_reason, label: false,
         collection: RespondentForm::NO_ACAS_REASON,
         as: :radio_buttons,
+        include_hidden: false,
         required: true,
         item_wrapper_class: 'block-label large-label'
       span.form-hint.toggle-content.reveal-acas-hint = t '.no_acas_number_note_two'

--- a/app/views/claims/_your_fee.html.slim
+++ b/app/views/claims/_your_fee.html.slim
@@ -16,6 +16,7 @@ fieldset
     p = t('.applying_for_remission_single_html', path: guide_path)
     = f.input :applying_for_remission,
       as: :radio_buttons,
+      include_hidden: false,
       item_wrapper_class: 'block-label',
       wrapper_html: { :class => 'form-group-reveal reveal-publish-delegate' },
       input_html: { :class => 'reveal-publish-publisher ga-vpv'},

--- a/app/views/diversities/_age_caring.html.slim
+++ b/app/views/diversities/_age_caring.html.slim
@@ -1,12 +1,14 @@
 fieldset
   = f.input :age_group,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::AgeCaringForm::AGE_GROUP,
     item_wrapper_class: 'govuk-radios__item',
     label: t('.age_group.hint'), input_html: {class: 'govuk-radios__input'}
 
   = f.input :caring_responsibility,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::AgeCaringForm::CARING_RESPONSIBILITY,
     item_wrapper_class: 'govuk-radios__item',
     label: t('.caring_responsibility.hint'),

--- a/app/views/diversities/_claim_type.html.slim
+++ b/app/views/diversities/_claim_type.html.slim
@@ -1,6 +1,8 @@
 fieldset
   = f.input :claim_type,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::ClaimTypeForm::CLAIM_TYPES,
+    include_hidden: false,
     item_wrapper_class: 'govuk-radios__item',
     label: false, input_html: {class: 'govuk-radios__input'}

--- a/app/views/diversities/_disability.html.slim
+++ b/app/views/diversities/_disability.html.slim
@@ -3,6 +3,7 @@ fieldset
   p = t('.conditions')
   = f.input :disability,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::DisabilityForm::DISABILITY,
     item_wrapper_class: 'govuk-radios__item',
     label: false, input_html: {class: 'govuk-radios__input'}

--- a/app/views/diversities/_ethnicity.html.slim
+++ b/app/views/diversities/_ethnicity.html.slim
@@ -1,6 +1,7 @@
 fieldset
   = f.input :ethnicity,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::EthnicityForm::ETHNICITY,
     item_wrapper_class: 'govuk-radios__item',
     label: false, input_html: {class: 'govuk-radios__input'}
@@ -9,6 +10,7 @@ fieldset
   fieldset class = "#{ethnicity_type} ethnicity_subgroup"
     = f.input :ethnicity_subgroup,
       as: :radio_buttons,
+      include_hidden: false,
       collection: Diversities::EthnicityForm::ETHNICITY_SUBGROUP[ethnicity_type],
       item_wrapper_class: 'govuk-radios__item',
       label: t("diversities.ethnicity_subgroup.header"), input_html: {class: 'govuk-radios__input'}

--- a/app/views/diversities/_identity.html.slim
+++ b/app/views/diversities/_identity.html.slim
@@ -1,6 +1,7 @@
 fieldset
   = f.input :sex,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::IdentityForm::SEX,
     item_wrapper_class: 'govuk-radios__item',
     label: t('.sex.hint'), input_html: {class: 'govuk-radios__input'}
@@ -8,6 +9,7 @@ fieldset
 fieldset
   = f.input :gender,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::IdentityForm::GENDER,
     item_wrapper_class: 'govuk-radios__item',
     label: t('.gender.hint'), input_html: {class: 'govuk-radios__input'}
@@ -15,6 +17,7 @@ fieldset
 fieldset
   = f.input :gender_at_birth,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::IdentityForm::GENDER_AT_BIRTH,
     item_wrapper_class: 'govuk-radios__item',
     label: t('.gender_at_birth.hint'), input_html: {class: 'govuk-radios__input'}
@@ -22,6 +25,7 @@ fieldset
 fieldset
   = f.input :sexual_identity,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::IdentityForm::SEXUAL_IDENTITY,
     item_wrapper_class: 'govuk-radios__item',
     label: t('.sexual_identity.hint'), input_html: {class: 'govuk-radios__input'}

--- a/app/views/diversities/_pregnancy.html.slim
+++ b/app/views/diversities/_pregnancy.html.slim
@@ -1,6 +1,7 @@
 fieldset
   = f.input :pregnancy,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::PregnancyForm::PREGNANCY,
     item_wrapper_class: 'govuk-radios__item',
     label: false, input_html: {class: 'govuk-radios__input'}

--- a/app/views/diversities/_relationship.html.slim
+++ b/app/views/diversities/_relationship.html.slim
@@ -1,6 +1,7 @@
 fieldset
   = f.input :relationship,
     as: :radio_buttons,
+    include_hidden: false,
     collection: Diversities::RelationshipForm::RELATIONSHIP,
     item_wrapper_class: 'govuk-radios__item',
     label: false, input_html: {class: 'govuk-radios__input'}

--- a/app/views/diversities/_religion.html.slim
+++ b/app/views/diversities/_religion.html.slim
@@ -1,6 +1,7 @@
 fieldset
   = f.input :religion,
     as: :radio_buttons,
+    include_hidden: false,
     collection:  Diversities::ReligionForm::RELIGION,
     item_wrapper_class: 'govuk-radios__item',
     label: false, input_html: {class: 'govuk-radios__input'}

--- a/app/views/refunds/_applicant.html.slim
+++ b/app/views/refunds/_applicant.html.slim
@@ -9,6 +9,7 @@ fieldset
   legend= t '.has_name_changed_legend'
   = f.input :has_name_changed,
           as: :radio_buttons,
+          include_hidden: false,
           required: true,
           label: false,
           item_wrapper_class: 'block-label',

--- a/app/views/refunds/_original_case_details.html.slim
+++ b/app/views/refunds/_original_case_details.html.slim
@@ -2,6 +2,7 @@ fieldset
   legend= t '.address_changed'
   = f.input :address_changed,
           as: :radio_buttons,
+          include_hidden: false,
           required: true,
           label: false,
           item_wrapper_class: 'block-label',
@@ -19,6 +20,7 @@ fieldset
   legend= t '.claim_had_representative'
   = f.input :claim_had_representative,
           as: :radio_buttons,
+          include_hidden: false,
           required: true,
           label: false,
           item_wrapper_class: 'block-label',

--- a/app/views/refunds/_profile_selection.html.slim
+++ b/app/views/refunds/_profile_selection.html.slim
@@ -2,6 +2,7 @@ fieldset.profile_selection
   legend = t('.profile_type')
   = f.input :profile_type,
           as: :radio_buttons,
+          include_hidden: false,
           label: false,
           required: true,
           item_wrapper_tag: :div,


### PR DESCRIPTION
This PR will do nothing right now - but I want it in before the rails 5 upgrade as it will switch off the hidden field which would otherwise get added to all radio buttons - meaning non selected values will be an empty string instead of nil.

In time, we can evaluate if we want it to use the rails 'norm' of an empty string of course