### PR TITLE
Now finalizing claim after submission to api

### DIFF
--- a/app/jobs/claim_submission_job.rb
+++ b/app/jobs/claim_submission_job.rb
@@ -6,6 +6,7 @@ class ClaimSubmissionJob < ActiveJob::Base
 
     claim.generate_pdf!
     EtApi.create_claim claim, uuid: uuid
+    claim.finalize!
 
     if claim.confirmation_email_recipients?
       BaseMailer.confirmation_email(claim).deliver

--- a/spec/jobs/claim_submission_job_spec.rb
+++ b/spec/jobs/claim_submission_job_spec.rb
@@ -9,6 +9,7 @@ describe ClaimSubmissionJob, type: :job do
     allow(BaseMailer).to receive(:confirmation_email).with(claim).and_return mailer
     allow(EtApi).to receive(:create_claim).with(claim, uuid: instance_of(String))
     allow(claim).to receive(:generate_pdf!)
+    allow(claim).to receive(:finalize!)
   end
 
   describe '#perform' do
@@ -19,6 +20,11 @@ describe ClaimSubmissionJob, type: :job do
 
     it 'generates the pdf' do
       expect(claim).to receive(:generate_pdf!)
+      claim_submission_job.perform(claim, SecureRandom.uuid)
+    end
+
+    it 'finalizes the claim' do
+      expect(claim).to receive(:finalize!)
       claim_submission_job.perform(claim, SecureRandom.uuid)
     end
 


### PR DESCRIPTION
After the release of v3.0.0 it was found that the claim was not having its status set to submitted.
This fixes that bug