### PR TITLE
RST-1447 Claims in dead queue on sidekig

### DIFF
--- a/app/presenters/pdf_form/base_delegator.rb
+++ b/app/presenters/pdf_form/base_delegator.rb
@@ -11,7 +11,7 @@ module PdfForm
       uk_postcode = UKPostcode.new(postcode ||= '')
 
       if uk_postcode.valid?
-        ("%-4s" % uk_postcode.outcode) + uk_postcode.incode
+        ("%-4s" % uk_postcode.outcode) + (uk_postcode.incode || '')
       else
         postcode
       end

--- a/app/presenters/pdf_form/base_delegator.rb
+++ b/app/presenters/pdf_form/base_delegator.rb
@@ -10,8 +10,8 @@ module PdfForm
     def format_postcode(postcode)
       uk_postcode = UKPostcode.new(postcode ||= '')
 
-      if uk_postcode.valid?
-        ("%-4s" % uk_postcode.outcode) + (uk_postcode.incode || '')
+      if uk_postcode.valid? && uk_postcode.outcode.present? && uk_postcode.incode.present?
+        ("%-4s" % uk_postcode.outcode) + uk_postcode.incode
       else
         postcode
       end

--- a/spec/presenters/pdf_form/base_delegator_spec.rb
+++ b/spec/presenters/pdf_form/base_delegator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PdfForm::BaseDelegator, type: :presenter do
         it { expect(pdf_form_base_delagator.format_postcode('m1 1aa')).to eq('M1  1AA') }
         it { expect(pdf_form_base_delagator.format_postcode('dn551pt')).to eq('DN551PT') }
         it { expect(pdf_form_base_delagator.format_postcode('a99aa')).to eq('A9  9AA') }
-        it { expect(pdf_form_base_delagator.format_postcode('1065')).to eq('IO65') }
+        it { expect(pdf_form_base_delagator.format_postcode('1065')).to eq('1065') }
       end
     end
 

--- a/spec/presenters/pdf_form/base_delegator_spec.rb
+++ b/spec/presenters/pdf_form/base_delegator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe PdfForm::BaseDelegator, type: :presenter do
         it { expect(pdf_form_base_delagator.format_postcode('m1 1aa')).to eq('M1  1AA') }
         it { expect(pdf_form_base_delagator.format_postcode('dn551pt')).to eq('DN551PT') }
         it { expect(pdf_form_base_delagator.format_postcode('a99aa')).to eq('A9  9AA') }
+        it { expect(pdf_form_base_delagator.format_postcode('1065')).to eq('IO65') }
       end
     end
 


### PR DESCRIPTION
A bug was found where a postcode used by a user caused it to fail to generate the pdf.  The postcode was a weird one '1083' - but apparently, the postcode validator converts it to IO83 which is valid !!
Irrespective of whether we agree with that, the code should be robust enough to handle it if thinks its valid.