### PR TITLE
RST-1469: Bootsnap in Production Only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,8 @@ end
 group :production do
   # Use Uglifier as compressor for JavaScript assets
   gem 'uglifier', '3.0.0'
+  # Only use bootsnap in prod to prevent debugging issues
+  gem 'bootsnap', '~> 1.3', '>= 1.3.1'
 end
 
 group :production, :test do
@@ -99,7 +101,6 @@ gem 'compass', '~> 1.0'
 gem 'zendesk_api', '~> 1.5.1x'
 gem 'email_validator', '~> 1.6'
 gem 'logstasher', '~> 1.2', groups: [:production, :local]
-gem 'bootsnap', '~> 1.3', '>= 1.3.1'
 
 # This gem ensures rails 4 also builds a non-digest version of the assets
 # so that static pages can refer to them.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require 'bootsnap/setup' if ENV['RAILS_ENV'] == 'production' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Bootsnap is used to cache operations and increase boot time. This can make debugging initialisers a pain in the backside, so this PR moves bootsnap to prod only.