### PR TITLE
Fixing failing tests after locale moved to url

### DIFF
--- a/config/locales/cy/guides.cy.yml
+++ b/config/locales/cy/guides.cy.yml
@@ -2,10 +2,10 @@ cy:
   guides:
     show:
       links:
-        time_limits_html: '<a href="?locale=cy#time_limits">Terfynau amser</a>'
-        acas_early_conciliation_html: '<a href="?locale=cy#acas_early_conciliation">Acas: cymodi cynnar</a>'
-        acas_early_conciliation_exceptions_html: '<a href="?locale=cy#acas_early_conciliation_exceptions">Eithriadau i gymodi cynnar</a>'
-        writing_your_claim_statement_html: '<a href="?locale=cy#writing_your_claim_statement">Ysgrifennu datganiad i gefnogi eich hawliad</a>'
+        time_limits_html: '<a href="#time_limits">Terfynau amser</a>'
+        acas_early_conciliation_html: '<a href="#acas_early_conciliation">Acas: cymodi cynnar</a>'
+        acas_early_conciliation_exceptions_html: '<a href="#acas_early_conciliation_exceptions">Eithriadau i gymodi cynnar</a>'
+        writing_your_claim_statement_html: '<a href="#writing_your_claim_statement">Ysgrifennu datganiad i gefnogi eich hawliad</a>'
 
     time_limits:
       title: Terfynau amser

--- a/config/locales/cy/terms.cy.yml
+++ b/config/locales/cy/terms.cy.yml
@@ -2,12 +2,12 @@ cy:
   terms:
     show:
       links:
-        general_html: '<a href="?locale=cy#general">Telerau ac amodau cyffredinol</a>'
-        applicable_law_html: '<a href="?locale=cy#applicable_law">Y gyfraith gymwys</a>'
-        responsible_html: "<a href='?locale=cy#responsible'>Defnydd cyfrifol o'r gwasanaeth hwn</a>"
-        gdpr_html: '<a href="?locale=cy#gdpr">Rheoliadau Cyffredinol Diogelu Data (GDPR)</a>'
-        hmcts_privacy_html: '<a href="?locale=cy#hmcts_privacy">Hysbysiad Preifatrwydd GLlTEM</a>'
-        disclaimer_html: '<a href="?locale=cy#disclaimer">Ymwrthodiad</a>'
+        general_html: '<a href="#general">Telerau ac amodau cyffredinol</a>'
+        applicable_law_html: '<a href="#applicable_law">Y gyfraith gymwys</a>'
+        responsible_html: "<a href='#responsible'>Defnydd cyfrifol o'r gwasanaeth hwn</a>"
+        gdpr_html: '<a href="#gdpr">Rheoliadau Cyffredinol Diogelu Data (GDPR)</a>'
+        hmcts_privacy_html: '<a href="#hmcts_privacy">Hysbysiad Preifatrwydd GLlTEM</a>'
+        disclaimer_html: '<a href="#disclaimer">Ymwrthodiad</a>'
       line_one: "Drwy ddefnyddio’r gwasanaeth ‘gwneud cais i dribiwnlys cyflogaeth’ hwn, rydych yn cytuno i’n polisi preifatrwydd a’r telerau ac amodau hyn. Darllenwch nhw’n ofalus."
 
       article_general:

--- a/config/locales/en/guides.en.yml
+++ b/config/locales/en/guides.en.yml
@@ -2,10 +2,10 @@ en:
   guides:
     show:
       links:
-        time_limits_html: '<a href="?locale=en#time_limits">Time limits</a>'
-        acas_early_conciliation_html: '<a href="?locale=en#acas_early_conciliation">Acas: early conciliation</a>'
-        acas_early_conciliation_exceptions_html: '<a href="?locale=en#acas_early_conciliation_exceptions">Exceptions to early conciliation</a>'
-        writing_your_claim_statement_html: '<a href="?locale=en#writing_your_claim_statement">Writing your claim statement</a>'
+        time_limits_html: '<a href="#time_limits">Time limits</a>'
+        acas_early_conciliation_html: '<a href="#acas_early_conciliation">Acas: early conciliation</a>'
+        acas_early_conciliation_exceptions_html: '<a href="#acas_early_conciliation_exceptions">Exceptions to early conciliation</a>'
+        writing_your_claim_statement_html: '<a href="#writing_your_claim_statement">Writing your claim statement</a>'
 
     time_limits:
       title: Time limits

--- a/config/locales/en/terms.en.yml
+++ b/config/locales/en/terms.en.yml
@@ -2,12 +2,12 @@ en:
   terms:
     show:
       links:
-        general_html: '<a href="?locale=en#general">General Terms and conditions</a>'
-        applicable_law_html: '<a href="?locale=en#applicable_law">Applicable law</a>'
-        responsible_html: '<a href="?locale=en#responsible">Responsible use of this service</a>'
-        gdpr_html: '<a href="?locale=en#gdpr">General Data Protection Regulations (GDPR)</a>'
-        hmcts_privacy_html: '<a href="?locale=en#hmcts_privacy">HMCTS Privacy Notice</a>'
-        disclaimer_html: '<a href="?locale=en#disclaimer">Disclaimer</a>'
+        general_html: '<a href="#general">General Terms and conditions</a>'
+        applicable_law_html: '<a href="#applicable_law">Applicable law</a>'
+        responsible_html: '<a href="#responsible">Responsible use of this service</a>'
+        gdpr_html: '<a href="#gdpr">General Data Protection Regulations (GDPR)</a>'
+        hmcts_privacy_html: '<a href="#hmcts_privacy">HMCTS Privacy Notice</a>'
+        disclaimer_html: '<a href="#disclaimer">Disclaimer</a>'
       line_one: "By using this ‘apply to an employment tribunal’ service you agree to our privacy policy and to these terms and conditions. Read them carefully."
 
       article_general:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,75 +6,83 @@ Rails.application.routes.draw do
   match "/500", :to => "errors#internal_server_error", :via => :all
   match "/503", :to => "errors#service_unavailable", :via => :all
 
-  scope :apply do
-    resource :guide,              only: :show
-    resource :terms,              only: :show
-    resource :cookies,            only: :show
-    resource :claim_review,       only: %i<show update>, path: :review
-    resource :pdf,                only: :show
-    resource :claim_confirmation, only: :show, path: :confirmation
+  scope "(:locale)", locale: /en|cy/ do
+    scope :apply do
+      resource :guide,              only: :show
+      resource :terms,              only: :show
+      resource :cookies,            only: :show
+      resource :claim_review,       only: %i<show update>, path: :review
+      resource :pdf,                only: :show
+      resource :claim_confirmation, only: :show, path: :confirmation
 
-    resource :claim, only: :create, path: "/" do
-      resource :payment, only: %i<show update>, path: :pay do
-        member do
-          %i<success decline>.each do |result|
-            get result, to: "payments##{result}", as: result
+      resource :claim, only: :create, path: "/" do
+        resource :payment, only: %i<show update>, path: :pay do
+          member do
+            %i<success decline>.each do |result|
+              get result, to: "payments##{result}", as: result
+            end
           end
+        end
+
+        %w<claimants respondents>.each do |page|
+          resource :"additional_#{page}", only: %i<show update>,
+            controller: :multiples, page: "additional-#{page}",
+            path: "additional-#{page}"
+        end
+
+        ClaimPagesManager.page_names.each do |page|
+          resource page.underscore, only: %i<show update>, controller: :claims,
+            page: page, path: page
         end
       end
 
-      %w<claimants respondents>.each do |page|
-        resource :"additional_#{page}", only: %i<show update>,
-          controller: :multiples, page: "additional-#{page}",
-          path: "additional-#{page}"
+      resource :refund, only: [:create, :new], path: "/refund" do
+        RefundPagesManager.page_names.each do |page|
+          resource page.underscore, only: %i<show update>, controller: :refunds,
+            page: page, path: page
+        end
       end
 
-      ClaimPagesManager.page_names.each do |page|
-        resource page.underscore, only: %i<show update>, controller: :claims,
-          page: page, path: page
+      resource :diversity, only: [:create, :new], path: "/diversity" do
+        DiversityPagesManager.page_names.each do |page|
+          resource page.underscore, only: %i<show update>, controller: :diversities,
+            page: page, path: page
+        end
       end
+      get 'diversity' => 'diversities#index', as: 'diversity_landing'
+
+      get 'ping' => 'ping#index'
+
+      get 'healthcheck' => 'healthcheck#index'
+
+      resource :user_session, only: %i<create destroy new>, path: :session do
+        member do
+          get :touch
+          get :expired
+        end
+      end
+
+      get  '/feedback' => 'feedback#new'
+      post '/feedback' => 'feedback#create'
+
+      get '/barclaycard-payment-template' => 'barclaycard_payment_template#show'
+
+      get '/stats' => 'stats#index'
     end
 
-    resource :refund, only: [:create, :new], path: "/refund" do
-      RefundPagesManager.page_names.each do |page|
-        resource page.underscore, only: %i<show update>, controller: :refunds,
-          page: page, path: page
-      end
-    end
+    get '/apply' => 'claims#new'
+    get '/apply/refund' => 'refunds#new'
+    root to: redirect('/apply')
+    get '/:locale/apply/admin', to: redirect('/apply/admin')
+    get '/:locale/apply/sidekiq', to: redirect('/apply/sidekiq')
 
-    resource :diversity, only: [:create, :new], path: "/diversity" do
-      DiversityPagesManager.page_names.each do |page|
-        resource page.underscore, only: %i<show update>, controller: :diversities,
-          page: page, path: page
-      end
-    end
-    get 'diversity' => 'diversities#index', as: 'diversity_landing'
+  end
 
-    get 'ping' => 'ping#index'
-
-    get 'healthcheck' => 'healthcheck#index'
-
-    resource :user_session, only: %i<create destroy new>, path: :session do
-      member do
-        get :touch
-        get :expired
-      end
-    end
-
-    get  '/feedback' => 'feedback#new'
-    post '/feedback' => 'feedback#create'
-
-    get '/barclaycard-payment-template' => 'barclaycard_payment_template#show'
-
-    get '/stats' => 'stats#index'
-
+  scope :apply do
     constraints(ip: /81\.134\.202\.29|127\.0\.0\.1|172\.\d+\.\d+\.\d+/) do
       ActiveAdmin.routes(self)
       mount Sidekiq::Web => '/sidekiq'
     end
   end
 
-  get '/apply' => 'claims#new'
-  get '/apply/refund' => 'refunds#new'
-  root to: redirect('/apply')
 end

--- a/features/support/page_objects/refund/payment_details_page.rb
+++ b/features/support/page_objects/refund/payment_details_page.rb
@@ -1,6 +1,6 @@
 module Refunds
   class PaymentDetailsPage < BasePage
-    set_url "/apply/refund/bank-details"
+    set_url "/en/apply/refund/bank-details"
     section :account_type, AppTest::FormSelect, :simple_form_field, 'Account type'
     section :bank_details, :xpath, (XPath.generate { |x| x.descendant(:fieldset)[x.descendant(:legend)[x.string.n.is("Your Bank Details")]] }) do
       section :account_name, AppTest::FormInput, :simple_form_field, 'Bank account holder name'

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe FeedbackController, type: :controller do
       before { post :create, params: { feedback: params } }
 
       it { expect(response).to have_http_status(302) }
-      it { expect(response.location).to end_with '/apply/feedback?locale=en' }
+      it { expect(response.location).to end_with '/en/apply/feedback' }
       it { expect(flash[:info]).to eq 'Thank you for your feedback' }
     end
   end

--- a/spec/features/create_claim_applications_spec.rb
+++ b/spec/features/create_claim_applications_spec.rb
@@ -299,7 +299,7 @@ feature 'Claim applications', type: :feature do
         perform_active_jobs(FeeGroupReferenceJob)
         perform_active_jobs(ClaimSubmissionJob)
         page_pdf_link = URI.parse(page.find_link('Save a copy')['href']).path
-        expect(page_pdf_link).to eq pdf_path
+        expect(page_pdf_link).to eq pdf_path(locale: :en)
 
         pdf_file_data = Claim.last.pdf.read
         pdf_data = pdf_to_hash(pdf_file_data)
@@ -317,7 +317,7 @@ feature 'Claim applications', type: :feature do
         remove_pdf_from_claim
         click_link 'Save a copy'
 
-        expect(current_path).to eq pdf_path
+        expect(current_path).to eq pdf_path(locale: :en)
         expect(page).to have_text "Processing a copy of your claim"
         expect(page).not_to have_signout_button
         expect(page).not_to have_session_prompt

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -31,17 +31,17 @@ feature 'Guide', type: :feature do
     end
 
     scenario "User can click time time_limits_link" do
-      expect(page).to have_link(time_limits_link, href: ("?locale=en" + time_limits_div).to_s)
+      expect(page).to have_link(time_limits_link, href: (time_limits_div).to_s)
       expect(page.find(time_limits_div)).not_to be_nil
     end
 
     scenario "User can click time acas_link" do
-      expect(page).to have_link(acas_link, href: ("?locale=en" + acas_div).to_s)
+      expect(page).to have_link(acas_link, href: (acas_div).to_s)
       expect(page.find(acas_div)).not_to be_nil
     end
 
     scenario "User can click time acas_exceptions_link" do
-      expect(page).to have_link(acas_exceptions_link, href: ("?locale=en" + acas_exceptions_div).to_s)
+      expect(page).to have_link(acas_exceptions_link, href: (acas_exceptions_div).to_s)
       expect(page.find(acas_exceptions_div)).not_to be_nil
     end
 
@@ -70,16 +70,16 @@ feature 'Guide', type: :feature do
       within('aside') { click_link 'Guide' }
       click_link 'Return to form'
 
-      expect(current_path).to eq claim_additional_claimants_path
+      expect(current_path).to eq claim_additional_claimants_path(locale: :en)
       click_button 'Save and continue'
-      expect(current_path).to eq claim_review_path
+      expect(current_path).to eq claim_review_path(locale: :en)
     end
 
     scenario 'Redirects to claim apply path when not referred from current site' do
       visit guide_path
       click_link 'Return to form'
 
-      expect(current_path).to eq apply_path
+      expect(current_path).to eq apply_path(locale: :en)
     end
   end
 end

--- a/spec/features/language_switch_spec.rb
+++ b/spec/features/language_switch_spec.rb
@@ -4,16 +4,16 @@ RSpec.feature 'Switching language', type: :feature do
 
   scenario 'hitting the stats end point returns json' do
     visit root_path
-    expect(page).to have_link("Cymraeg", href: '/apply?locale=cy')
+    expect(page).to have_link("Cymraeg", href: '/cy/apply')
     expect(page).to have_text("Make a claim to an employment tribunal")
     click_link('Cymraeg')
 
-    expect(page).to have_link("English", href: '/apply?locale=en')
+    expect(page).to have_link("English", href: '/en/apply')
     expect(page).to have_text("Gwneud hawliad i dribiwnlys cyflogaeth")
 
     click_link('English')
     expect(page).to have_text("Make a claim to an employment tribunal")
-    expect(page).to have_link("Cymraeg", href: '/apply?locale=cy')
+    expect(page).to have_link("Cymraeg", href: '/cy/apply')
   end
 
   scenario 'langauge should persist after submitting the form' do
@@ -21,20 +21,16 @@ RSpec.feature 'Switching language', type: :feature do
     click_button 'Start a claim'
 
     expect(page).to have_text('Saving your claim')
-    expect(current_langauge_selector).to eql('locale=en')
+    expect(current_path).to eql('/en/apply/application-number')
     click_link('Cymraeg')
 
     expect(page).to have_text('Cadw eich hawliad')
-    expect(current_langauge_selector).to eql('locale=cy')
+    expect(current_path).to eql('/cy/apply/application-number')
     click_button('Cadw a pharhau')
 
     expect(page).to have_text('Mae gwallau ar y dudalen')
     expect(page).to have_text("Dylech greu gair cofiadwy er mwyn i chi allu dychwelyd i'ch hawliad")
-    expect(current_langauge_selector).to eql('locale=cy')
+    expect(current_path).to eql('/cy/apply/application-number')
   end
 
-end
-
-def current_langauge_selector
-  current_url.split('?').last
 end

--- a/spec/features/preventing_login_after_submission_spec.rb
+++ b/spec/features/preventing_login_after_submission_spec.rb
@@ -11,7 +11,7 @@ feature 'Login after submission', type: :feature do
     visit new_user_session_path
     fill_in_return_form claim.reference, 'lololol'
 
-    expect(page.current_path).to eq user_session_path
+    expect(page.current_path).to eq user_session_path(locale: :en)
     expect(page).to have_text "This claim has been submitted and can no longer be edited online"
   end
 end

--- a/spec/features/quick_edit_spec.rb
+++ b/spec/features/quick_edit_spec.rb
@@ -14,81 +14,81 @@ feature 'Quick edit' do
     within(".claimant") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/claimant"
+    expect(page.current_path).to eq "/en/apply/claimant"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
   scenario "editing 'Group claim'" do
     within(".additional-claimants") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/additional-claimants"
+    expect(page.current_path).to eq "/en/apply/additional-claimants"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
   scenario "editing 'Representative’s details'" do
     within(".representative") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/representative"
+    expect(page.current_path).to eq "/en/apply/representative"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
   scenario "editing 'Respondent’s details'" do
     within(".respondent") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/respondent"
+    expect(page.current_path).to eq "/en/apply/respondent"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
   scenario "editing 'Employment details'" do
     within(".employment") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/employment"
+    expect(page.current_path).to eq "/en/apply/employment"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
   scenario "editing 'Claim type'" do
     within(".claim-type") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/claim-type"
+    expect(page.current_path).to eq "/en/apply/claim-type"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
   scenario "editing 'Claim details'" do
     within(".claim-details") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/claim-details"
+    expect(page.current_path).to eq "/en/apply/claim-details"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
   scenario "editing 'Claim outcome'" do
     within(".claim-outcome") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/claim-outcome"
+    expect(page.current_path).to eq "/en/apply/claim-outcome"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
   scenario "editing 'Additional information'" do
     within(".additional-information") do
       click_link 'Edit'
     end
-    expect(page.current_path).to eq "/apply/additional-information"
+    expect(page.current_path).to eq "/en/apply/additional-information"
     click_button 'Save and continue'
-    expect(page.current_path).to eq "/apply/review"
+    expect(page.current_path).to eq "/en/apply/review"
   end
 
 

--- a/spec/features/request_redispatch_spec.rb
+++ b/spec/features/request_redispatch_spec.rb
@@ -57,7 +57,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the payment page' do
             visit claim_claimant_path
-            expect(page.current_path).to eq claim_payment_path
+            expect(page.current_path).to eq claim_payment_path(locale: :en)
           end
         end
 
@@ -66,7 +66,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the confirmation page' do
             visit claim_claimant_path
-            expect(page.current_path).to eq claim_confirmation_path
+            expect(page.current_path).to eq claim_confirmation_path(locale: :en)
           end
         end
 
@@ -75,7 +75,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the confirmation page' do
             visit claim_claimant_path
-            expect(page.current_path).to eq claim_confirmation_path
+            expect(page.current_path).to eq claim_confirmation_path(locale: :en)
           end
         end
       end
@@ -95,7 +95,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the payment page' do
             visit claim_review_path
-            expect(page.current_path).to eq claim_payment_path
+            expect(page.current_path).to eq claim_payment_path(locale: :en)
           end
         end
 
@@ -104,7 +104,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the confirmation page' do
             visit claim_review_path
-            expect(page.current_path).to eq claim_confirmation_path
+            expect(page.current_path).to eq claim_confirmation_path(locale: :en)
           end
         end
 
@@ -113,7 +113,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the confirmation page' do
             visit claim_review_path
-            expect(page.current_path).to eq claim_confirmation_path
+            expect(page.current_path).to eq claim_confirmation_path(locale: :en)
           end
         end
       end
@@ -133,7 +133,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the claimant page' do
             visit claim_payment_path
-            expect(page.current_path).to eq claim_claimant_path
+            expect(page.current_path).to eq claim_claimant_path(locale: :en)
           end
         end
 
@@ -142,7 +142,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the confirmation page' do
             visit claim_payment_path
-            expect(page.current_path).to eq claim_confirmation_path
+            expect(page.current_path).to eq claim_confirmation_path(locale: :en)
           end
         end
 
@@ -151,7 +151,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the confirmation page' do
             visit claim_payment_path
-            expect(page.current_path).to eq claim_confirmation_path
+            expect(page.current_path).to eq claim_confirmation_path(locale: :en)
           end
         end
       end
@@ -180,7 +180,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the claimant page' do
             visit claim_confirmation_path
-            expect(page.current_path).to eq claim_claimant_path
+            expect(page.current_path).to eq claim_claimant_path(locale: :en)
           end
         end
 
@@ -189,7 +189,7 @@ feature 'Request redispatch' do
 
           it 'redirects to the payment page' do
             visit claim_review_path
-            expect(page.current_path).to eq claim_payment_path
+            expect(page.current_path).to eq claim_payment_path(locale: :en)
           end
         end
       end

--- a/spec/features/session_expiry_spec.rb
+++ b/spec/features/session_expiry_spec.rb
@@ -13,7 +13,7 @@ feature 'Session Expiry', type: :feature do
           travel_to TimeHelper.session_expiry_time do
             visit(page_name.to_s)
             expect(page).to have_text 'Session expired'
-            expect(current_path).to eq expired_user_session_path
+            expect(current_path).to eq expired_user_session_path(locale: :en)
           end
         end
       end
@@ -21,7 +21,7 @@ feature 'Session Expiry', type: :feature do
       scenario 'a user is unable to re-enter the form from the expiry page' do
         travel_to TimeHelper.session_expiry_time do
           visit claim_claimant_path
-          expect(current_path).to eq expired_user_session_path
+          expect(current_path).to eq expired_user_session_path(locale: :en)
           visit claim_claimant_path
           expect(current_path).to eq apply_path
         end
@@ -34,7 +34,7 @@ feature 'Session Expiry', type: :feature do
       visit apply_path
       travel_to TimeHelper.session_expiry_time do
         click_button 'Start a claim'
-        expect(current_path).to eq claim_application_number_path
+        expect(current_path).to eq claim_application_number_path(locale: :en)
       end
     end
   end

--- a/spec/features/terms_spec.rb
+++ b/spec/features/terms_spec.rb
@@ -68,32 +68,32 @@ feature 'Terms' do
   end
 
   scenario "User can click general link" do
-    expect(page).to have_link(general_link, href: "?locale=en" + general_div.to_s)
+    expect(page).to have_link(general_link, href: general_div.to_s)
     expect(page.find(general_div)).not_to be_nil
   end
 
   scenario "User can click applicable law link" do
-    expect(page).to have_link(applicable_law_link, href: "?locale=en" + applicable_law_div.to_s)
+    expect(page).to have_link(applicable_law_link, href: applicable_law_div.to_s)
     expect(page.find(applicable_law_div)).not_to be_nil
   end
 
   scenario "User can click applicable law responsible use link" do
-    expect(page).to have_link(applicable_law_responsible_use_link, href: "?locale=en" + applicable_law_responsible_use_div.to_s)
+    expect(page).to have_link(applicable_law_responsible_use_link, href: applicable_law_responsible_use_div.to_s)
     expect(page.find(applicable_law_div)).not_to be_nil
   end
 
   scenario "User can click privacy policy link" do
-    expect(page).to have_link(privacy_policy_link, href: "?locale=en" + privacy_policy_div.to_s)
+    expect(page).to have_link(privacy_policy_link, href: privacy_policy_div.to_s)
     expect(page.find(privacy_policy_div)).not_to be_nil
   end
 
   scenario "User can click data protection link" do
-    expect(page).to have_link(data_protection_link, href: "?locale=en" + data_protection_div.to_s)
+    expect(page).to have_link(data_protection_link, href: data_protection_div.to_s)
     expect(page.find(privacy_policy_div)).not_to be_nil
   end
 
   scenario "User can click disclaimer link" do
-    expect(page).to have_link(disclaimer_link, href: "?locale=en" + disclaimer_div.to_s)
+    expect(page).to have_link(disclaimer_link, href: disclaimer_div.to_s)
     expect(page.find(privacy_policy_div)).not_to be_nil
   end
 end

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ClaimsHelper, type: :helper do
   let(:english_link) { 'https://www.gov.uk/done/employment-tribunals-make-a-claim' }
-  let(:default_link) { "/apply/feedback?locale=#{I18n.locale}" }
+  let(:default_link) { "/#{I18n.locale}/apply/feedback" }
 
   describe 'feedback link' do
     context 'when English' do


### PR DESCRIPTION
There is a requirement for a locale to be part of the URL. This is the PR that does just that. The url without locale in it will still work.