### PR TITLE
Allow pdf flatten config by environment (production only)

### DIFF
--- a/app/services/pdf_form_builder.rb
+++ b/app/services/pdf_form_builder.rb
@@ -13,7 +13,7 @@ class PdfFormBuilder
   end
 
   def perform(&_block)
-    pdf_builder.fill_form(ET1_PDF_PATH, tempfile, document_data, flatten: !Rails.env.test?)
+    pdf_builder.fill_form(ET1_PDF_PATH, tempfile, document_data, flatten: Rails.application.config.flatten_pdf)
     yield tempfile
     tempfile.close!
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,6 +82,7 @@ Rails.application.configure do
   config.action_mailer.default_options = { from: 'no-reply@lol.biz.info' }
   config.active_job.queue_adapter = :sidekiq
 
+  config.flatten_pdf = false
 end
 
 Slim::Engine.set_default_options pretty: true, sort_attrs: true

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -117,6 +117,8 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.active_job.queue_adapter = :sidekiq
+
+  config.flatten_pdf = false
 end
 CarrierWave.configure do |config|
   config.storage :fog

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -123,6 +123,8 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
 
   config.secure_session_cookie = true
+
+  config.flatten_pdf = true
 end
 CarrierWave.configure do |config|
   config.storage :fog

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,6 +58,8 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :test
+
+  config.flatten_pdf = false
 end
 
 CarrierWave.configure do |config|


### PR DESCRIPTION
This PR is required to allow testing of pdf's in all but production environments.  Previously, every environment apart from test would flatten the pdf - screwing any chance we had of reading its contents.

It is very simple - the decision to flatten or not comes from the config now - which is then set each environment config - so all but production set it to false.