### PR TITLE
Fixed bug where the 'No' option of the 'Yes/No' selection is readonly

### DIFF
--- a/app/views/claims/_additional_claimants.html.slim
+++ b/app/views/claims/_additional_claimants.html.slim
@@ -3,6 +3,7 @@ fieldset
 
   = f.input :of_collection_type,
     as: :radio_buttons,
+    readonly: nil,
     item_wrapper_class: 'block-label',
     wrapper_class: 'form-group-reveal reveal-publish-delegate',
     input_html: { :class => 'reveal-publish-publisher ga-vpv'},

--- a/app/views/claims/_additional_respondents.html.slim
+++ b/app/views/claims/_additional_respondents.html.slim
@@ -4,6 +4,7 @@ fieldset
 
   = f.input :of_collection_type,
     as: :radio_buttons,
+    readonly: nil,
     include_hidden: false,
     label: false,
     item_wrapper_class: 'block-label',


### PR DESCRIPTION
Fixed bug where the 'No' option of the 'Yes/No' selection for additional claimants and respondents page was being marked as read only - preventing it from being selected.  Luckily, it was selected by default.