### PR TITLE
RST-1521 ET1 - Upgrade rack to 2.0.6 or later due to vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.3)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-livereload (0.3.17)
       rack
     rack-protection (2.0.3)


### PR DESCRIPTION
Upgrade rack to 2.0.6