### PR TITLE
Ensure empty hash is sent to API when 'no address' is meant - RST-163…

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,7 @@
 class Address < ApplicationRecord
   belongs_to :addressable, polymorphic: true, optional: true
+
+  def empty?
+    building.nil? && street.nil? && locality.nil? && county.nil? && post_code.nil?
+  end
 end

--- a/app/views/api/claim/_build_primary_representative.json.jbuilder
+++ b/app/views/api/claim/_build_primary_representative.json.jbuilder
@@ -4,12 +4,16 @@ json.data do
   json.name representative.name
   json.organisation_name representative.organisation_name
   representative.address.tap do |a|
-    json.address_attributes do
-      json.building a.try(:building)
-      json.street a.try(:street)
-      json.locality a.try(:locality)
-      json.county a.try(:county)
-      json.post_code a.try(:post_code)
+    if a.nil? ||a.blank?
+      json.address_attributes({})
+    else
+      json.address_attributes do
+        json.building a.building
+        json.street a.street
+        json.locality a.locality
+        json.county a.county
+        json.post_code a.post_code
+      end
     end
   end
 

--- a/app/views/api/claim/_build_primary_representative.json.jbuilder
+++ b/app/views/api/claim/_build_primary_representative.json.jbuilder
@@ -4,7 +4,7 @@ json.data do
   json.name representative.name
   json.organisation_name representative.organisation_name
   representative.address.tap do |a|
-    if a.nil? ||a.blank?
+    if a.nil? ||a.empty?
       json.address_attributes({})
     else
       json.address_attributes do

--- a/app/views/api/claim/_respondent_attributes.json.jbuilder
+++ b/app/views/api/claim/_respondent_attributes.json.jbuilder
@@ -1,22 +1,30 @@
 json.name respondent.name
 json.contact nil
 respondent.address.tap do |a|
-  json.address_attributes do
-    json.building a.try(:building)
-    json.street a.try(:street)
-    json.locality a.try(:locality)
-    json.county a.try(:county)
-    json.post_code a.try(:post_code)
+  if a.empty?
+    json.address_attributes({})
+  else
+    json.address_attributes do
+      json.building a.building
+      json.street a.street
+      json.locality a.locality
+      json.county a.county
+      json.post_code a.post_code
+    end
   end
 end
 
 respondent.work_address.tap do |a|
-  json.work_address_attributes do
-    json.building a.try(:building)
-    json.street a.try(:street)
-    json.locality a.try(:locality)
-    json.county a.try(:county)
-    json.post_code a.try(:post_code)
+  if a.empty?
+    json.work_address_attributes({})
+  else
+    json.work_address_attributes do
+      json.building a.building
+      json.street a.street
+      json.locality a.locality
+      json.county a.county
+      json.post_code a.post_code
+    end
   end
 end
 json.address_telephone_number respondent.address_telephone_number

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -92,6 +92,24 @@ FactoryGirl.define do
       end
     end
 
+    trait :primary_respondent_with_no_work_address do
+      primary_respondent do
+        build(:respondent, addresses: [build(:address, primary: true)])
+      end
+    end
+
+    trait :primary_respondent_with_no_addresses do
+      primary_respondent do
+        build(:respondent, addresses: [build(:address, primary: true)])
+      end
+    end
+
+    trait :primary_representative_with_no_address do
+      representative do
+        build(:representative, address: nil)
+      end
+    end
+
     trait :with_pdf do
       after(:create, &:generate_pdf!)
     end

--- a/spec/services/et_api_spec.rb
+++ b/spec/services/et_api_spec.rb
@@ -85,6 +85,54 @@ RSpec.describe EtApi, type: :service do
       it { is_expected.not_to contain_api_command('BuildClaimDetailsFile') }
     end
 
+    context 'with a claim with single claimant, single respondent (with no work address) and a representative' do
+      include_context 'with action performed before each example'
+      let(:example_claim) { create(:claim, :with_pdf, :no_attachments, :primary_respondent_with_no_work_address) }
+
+      it { is_expected.to contain_valid_api_command('BuildPrimaryClaimant').version('2').for_db_data(example_claim.primary_claimant) }
+      it { is_expected.to contain_valid_api_command('BuildPrimaryRespondent').version('2').for_db_data(example_claim.primary_respondent) }
+      it { is_expected.to contain_valid_api_command('BuildPrimaryRepresentative').version('2').for_db_data(example_claim.representative) }
+      it { is_expected.to contain_valid_api_command('BuildClaim').version('2').for_db_data(example_claim) }
+      it { is_expected.to contain_valid_api_command('BuildPdfFile').version('2').for_db_data(example_claim.pdf) }
+      it { is_expected.not_to contain_api_command('BuildSecondaryClaimants') }
+      it { is_expected.not_to contain_api_command('BuildSecondaryRespondents') }
+      it { is_expected.not_to contain_api_command('BuildSecondaryRepresentatives') }
+      it { is_expected.not_to contain_api_command('BuildClaimantsFile') }
+      it { is_expected.not_to contain_api_command('BuildClaimDetailsFile') }
+    end
+
+    context 'with a claim with single claimant, single respondent (with no addresses) and a representative' do
+      include_context 'with action performed before each example'
+      let(:example_claim) { create(:claim, :with_pdf, :no_attachments, :primary_respondent_with_no_addresses) }
+
+      it { is_expected.to contain_valid_api_command('BuildPrimaryClaimant').version('2').for_db_data(example_claim.primary_claimant) }
+      it { is_expected.to contain_valid_api_command('BuildPrimaryRespondent').version('2').for_db_data(example_claim.primary_respondent) }
+      it { is_expected.to contain_valid_api_command('BuildPrimaryRepresentative').version('2').for_db_data(example_claim.representative) }
+      it { is_expected.to contain_valid_api_command('BuildClaim').version('2').for_db_data(example_claim) }
+      it { is_expected.to contain_valid_api_command('BuildPdfFile').version('2').for_db_data(example_claim.pdf) }
+      it { is_expected.not_to contain_api_command('BuildSecondaryClaimants') }
+      it { is_expected.not_to contain_api_command('BuildSecondaryRespondents') }
+      it { is_expected.not_to contain_api_command('BuildSecondaryRepresentatives') }
+      it { is_expected.not_to contain_api_command('BuildClaimantsFile') }
+      it { is_expected.not_to contain_api_command('BuildClaimDetailsFile') }
+    end
+
+    context 'with a claim with single claimant, single respondent and a representative (with no address)' do
+      include_context 'with action performed before each example'
+      let(:example_claim) { create(:claim, :with_pdf, :no_attachments, :primary_representative_with_no_address) }
+
+      it { is_expected.to contain_valid_api_command('BuildPrimaryClaimant').version('2').for_db_data(example_claim.primary_claimant) }
+      it { is_expected.to contain_valid_api_command('BuildPrimaryRespondent').version('2').for_db_data(example_claim.primary_respondent) }
+      it { is_expected.to contain_valid_api_command('BuildPrimaryRepresentative').version('2').for_db_data(example_claim.representative) }
+      it { is_expected.to contain_valid_api_command('BuildClaim').version('2').for_db_data(example_claim) }
+      it { is_expected.to contain_valid_api_command('BuildPdfFile').version('2').for_db_data(example_claim.pdf) }
+      it { is_expected.not_to contain_api_command('BuildSecondaryClaimants') }
+      it { is_expected.not_to contain_api_command('BuildSecondaryRespondents') }
+      it { is_expected.not_to contain_api_command('BuildSecondaryRepresentatives') }
+      it { is_expected.not_to contain_api_command('BuildClaimantsFile') }
+      it { is_expected.not_to contain_api_command('BuildClaimDetailsFile') }
+    end
+
     context 'with a claim with single claimant, single respondent and no representative' do
       include_context 'with action performed before each example'
       let(:example_claim) { create(:claim, :with_pdf, :without_representative, :no_attachments) }

--- a/spec/support/api_support/json_objects/v2/claimant_json_object.rb
+++ b/spec/support/api_support/json_objects/v2/claimant_json_object.rb
@@ -19,7 +19,7 @@ module Et1
                                          special_needs: example_claimant.special_needs,
                                          mobile_number: example_claimant.mobile_number,
                                          address_telephone_number: example_claimant.address_telephone_number,
-                                         address_attributes: example_address.nil? ? nil : a_hash_including(building: example_address.building, county: example_address.county, locality: example_address.locality, post_code: example_address.post_code, street: example_address.street)
+                                         address_attributes: example_address.nil? || example_address.empty? ? {} : a_hash_including(building: example_address.building, county: example_address.county, locality: example_address.locality, post_code: example_address.post_code, street: example_address.street)
           rescue RSpec::Expectations::ExpectationNotMetError => err
             errors << "Missing or invalid claimant json"
             errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })

--- a/spec/support/api_support/json_objects/v2/representative_json_object.rb
+++ b/spec/support/api_support/json_objects/v2/representative_json_object.rb
@@ -8,7 +8,7 @@ module Et1
 
           def has_valid_json_for_model?(example_rep, errors: [], indent: 1)
             example_address = example_rep.address
-            expect(json).to include address_attributes: a_hash_including(building: example_address.building, county: example_address.county, locality: example_address.locality, post_code: example_address.post_code, street: example_address.street),
+            expect(json).to include address_attributes: example_address.nil? || example_address.empty? ? {} : a_hash_including(building: example_address.building, county: example_address.county, locality: example_address.locality, post_code: example_address.post_code, street: example_address.street),
                                     address_telephone_number: example_rep.address_telephone_number,
                                     contact_preference: nil,
                                     dx_number: example_rep.dx_number,

--- a/spec/support/api_support/json_objects/v2/respondent_json_object.rb
+++ b/spec/support/api_support/json_objects/v2/respondent_json_object.rb
@@ -11,7 +11,7 @@ module Et1
             example_work_address = example_respondent.work_address
             expect(json).to include acas_certificate_number: example_respondent.acas_early_conciliation_certificate_number,
                                     acas_exemption_code: example_respondent.no_acas_number_reason,
-                                    address_attributes: a_hash_including(building: example_address.building, county: example_address.county, locality: example_address.locality, post_code: example_address.post_code, street: example_address.street),
+                                    address_attributes: example_address.nil? || example_address.empty? ? {} : a_hash_including(building: example_address.building, county: example_address.county, locality: example_address.locality, post_code: example_address.post_code, street: example_address.street),
                                     address_telephone_number: example_respondent.address_telephone_number,
                                     alt_phone_number: example_respondent.work_address_telephone_number,
                                     contact: nil,
@@ -25,7 +25,7 @@ module Et1
                                     name: example_respondent.name,
                                     organisation_employ_gb: nil,
                                     organisation_more_than_one_site: nil,
-                                    work_address_attributes: example_work_address.nil? ? nil : a_hash_including(building: example_work_address.building, county: example_work_address.county, locality: example_work_address.locality, post_code: example_work_address.post_code, street: example_work_address.street),
+                                    work_address_attributes: example_work_address.nil? || example_work_address.empty? ? {} : a_hash_including(building: example_work_address.building, county: example_work_address.county, locality: example_work_address.locality, post_code: example_work_address.post_code, street: example_work_address.street),
                                     work_address_telephone_number: example_respondent.work_address_telephone_number
 
           rescue RSpec::Expectations::ExpectationNotMetError => err


### PR DESCRIPTION
This PR ensures that an empty hash is sent to API when 'no address' is meant.

The API will accept this - and always has done - so no compatibility issues.

This prevents the 'empty addresses' in the API / Admin - at the root cause.