### PR TITLE
RST-1757 ET1 (Azure) Asset configuration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,6 +33,8 @@ Rails.application.configure do
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
+  config.asset_host = ENV['ASSET_HOST'] if ENV['ASSET_HOST'].present?
+  config.assets.prefix = ENV['ASSET_PREFIX'] if ENV['ASSET_PREFIX'].present?
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
RST-1757 ET1 (Azure) Asset configuration

This must not be deployed until ben has done his bit.  It is preparing for azure where we will correct the silly '/apply/assets' inconsistency in et1
Ben's ticket is https://tools.hmcts.net/jira/browse/RDO-3581