### PR TITLE
RST-1757 ET1 (Azure) Asset configuration

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,6 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   # This makes rails serve all the assets from under /apply as they are in prod.
-  config.assets.prefix = "apply/assets"
   config.relative_url_root = ""
 
   # Debug mode disables concatenation and preprocessing of assets.

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -25,7 +25,6 @@ Rails.application.configure do
   config.serve_static_files = true
 
   # This makes rails serve all the assets from under /apply as they are in prod.
-  config.assets.prefix = "apply/assets"
   config.relative_url_root = ""
 
   # Compress JavaScripts and CSS.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,6 @@ Rails.application.configure do
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
   config.asset_host = ENV['ASSET_HOST'] if ENV['ASSET_HOST'].present?
-  config.assets.prefix = ENV['ASSET_PREFIX'] if ENV['ASSET_PREFIX'].present?
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
Removed assets prefix - this has now been removed from the environment by devops so et1 is now the same as every other normal rails app with respect to assets